### PR TITLE
test: 补齐 NowPlaying 元数据与回调覆盖

### DIFF
--- a/src/aionowplaying/nowplaying.py
+++ b/src/aionowplaying/nowplaying.py
@@ -143,8 +143,42 @@ class NowPlaying:
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
         """Apply metadata to the playback properties."""
-        # Will be implemented in later tasks
-        pass
+        metadata_bean = self._interface._playback_properties.Metadata
+
+        field_aliases = {
+            'id': 'id_',
+            'id_': 'id_',
+            'media_type': 'media_type',
+            'duration': 'duration',
+            'cover': 'cover',
+            'album': 'album',
+            'album_artist': 'albumArtist',
+            'albumArtist': 'albumArtist',
+            'artist': 'artist',
+            'lyrics': 'lyrics',
+            'comments': 'comments',
+            'composer': 'composer',
+            'genre': 'genre',
+            'lyricist': 'lyricist',
+            'title': 'title',
+            'track_number': 'trackNumber',
+            'trackNumber': 'trackNumber',
+            'url': 'url',
+        }
+
+        list_fields = {'albumArtist', 'artist', 'comments', 'composer', 'genre', 'lyricist'}
+
+        for key, value in metadata.items():
+            target = field_aliases.get(key)
+            if target is None:
+                continue
+            if target in list_fields and isinstance(value, str):
+                value = [value]
+            if target == 'duration' and isinstance(value, timedelta):
+                value = self._timedelta_to_microseconds(value)
+            setattr(metadata_bean, target, value)
+
+        self._interface.set_playback_property(PlaybackPropertyName.Metadata, metadata_bean)
 
     @staticmethod
     def _timedelta_to_microseconds(td: timedelta) -> int:

--- a/tests/test_nowplaying.py
+++ b/tests/test_nowplaying.py
@@ -2,6 +2,7 @@ import pytest
 
 import aionowplaying as aionp
 from aionowplaying import NowPlaying, PlaybackPropertyName, PlaybackStatus, LoopStatus
+from aionowplaying.interface.base import MediaType
 from datetime import timedelta
 import asyncio
 import warnings
@@ -107,6 +108,55 @@ def test_nowplaying_init_with_identity():
     player = NowPlaying("Test Player", identity="Custom Identity")
     assert player.name == "Test Player"
     assert player._identity == "Custom Identity"
+
+
+def test_init_applies_metadata_mapping():
+    """Test that initial metadata is mapped onto NowPlaying properties."""
+    metadata = {
+        "title": "Mapped Song",
+        "artist": "Solo Artist",
+        "album": "Mapped Album",
+        "album_artist": "Album Artist",
+        "cover": "file:///tmp/cover.png",
+        "url": "file:///tmp/song.mp3",
+        "track_number": 7,
+        "duration": timedelta(minutes=4, seconds=5),
+    }
+
+    player = NowPlaying("Test Player", metadata=metadata)
+
+    assert player.title == "Mapped Song"
+    assert player.artist == ["Solo Artist"]
+    assert player.album == "Mapped Album"
+    assert player.album_artist == ["Album Artist"]
+    assert player.cover == "file:///tmp/cover.png"
+    assert player.url == "file:///tmp/song.mp3"
+    assert player.track_number == 7
+    assert player.duration == timedelta(minutes=4, seconds=5)
+
+
+def test_init_applies_extended_metadata_fields():
+    """Test metadata fields stored directly on the underlying MetadataBean."""
+    metadata = {
+        "id": "track-123",
+        "media_type": MediaType.Video,
+        "composer": ["Composer"],
+        "genre": ["Genre"],
+        "lyrics": "lyrics",
+        "comments": ["comment"],
+        "lyricist": ["Lyricist"],
+    }
+
+    player = NowPlaying("Test Player", metadata=metadata)
+    applied = player._interface.get_playback_property(PlaybackPropertyName.Metadata)
+
+    assert applied.id_ == "track-123"
+    assert applied.media_type == MediaType.Video
+    assert applied.composer == ["Composer"]
+    assert applied.genre == ["Genre"]
+    assert applied.lyrics == "lyrics"
+    assert applied.comments == ["comment"]
+    assert applied.lyricist == ["Lyricist"]
 
 
 def test_capability_inference_from_callbacks():
@@ -320,6 +370,39 @@ async def test_callback_execution():
 
     assert 'play' in call_log
     assert 'pause' in call_log
+
+
+@pytest.mark.asyncio
+async def test_seek_callback_converts_microseconds_to_timedelta():
+    """Test seek callback wrapper converts microseconds to timedelta."""
+    offsets = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_seek=lambda delta: offsets.append(delta),
+    )
+
+    await player._interface.on_seek(2_500_000)
+
+    assert offsets == [timedelta(seconds=2, microseconds=500000)]
+
+
+@pytest.mark.asyncio
+async def test_async_callback_is_scheduled():
+    """Test async callback results are scheduled as tasks."""
+    seen = []
+    callback_done = asyncio.Event()
+
+    async def on_play():
+        seen.append("play")
+        callback_done.set()
+
+    player = NowPlaying("Test Player", on_play=on_play)
+
+    await player._interface.on_play()
+    await asyncio.wait_for(callback_done.wait(), timeout=1)
+
+    assert seen == ["play"]
 
 
 def test_select_interface_deprecation():


### PR DESCRIPTION
## Summary
- 实现 `NowPlaying._apply_metadata()`，支持初始化 metadata 的字段映射、列表归一化和 `timedelta` 时长转换
- 为 `NowPlaying` 补充初始化 metadata、扩展 metadata 字段、seek 回调转换、异步回调调度测试
- 覆盖 issue #23 中最直接的 `nowplaying.py` 测试缺口

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_nowplaying.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`

Closes #23