### PR TITLE
[codex] 完善 OpenUri 与 URI 激活支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ import asyncio
 from datetime import timedelta
 from aionowplaying import NowPlaying
 
-# Create player with metadata and callbacks
+# Wire media callbacks to your own application logic.
+def handle_play():
+    pass
+
+def handle_pause():
+    pass
+
 player = NowPlaying(
     "My Player",
     metadata={
@@ -48,9 +54,8 @@ player = NowPlaying(
         "album": "Album",
         "duration": timedelta(minutes=3, seconds=30),
     },
-    on_play=lambda: my_player.play(),
-    on_pause=lambda: my_player.pause(),
-    on_next=lambda: my_player.next(),
+    on_play=handle_play,
+    on_pause=handle_pause,
 )
 
 # Update metadata during playback
@@ -124,9 +129,25 @@ The tables below describe native backend coverage for each `BaseInterface` metho
 | Method | Linux (MPRIS2) | macOS | Windows |
 | --- | --- | --- | --- |
 | `on_seek` | 🟢 Native<br>offset seek | 🟡 Partial<br>absolute position | 🟡 Partial<br>absolute position |
-| `on_open_uri` | 🟢 Native<br>`OpenUri` command | 🔴 Unimplemented | 🔴 Unimplemented |
+| `on_open_uri` | 🟢 Native<br>`OpenUri` command | 🟡 Library helper<br>open URI from current process | 🟡 Library helper<br>open URI from current process |
 | `on_set_position` | 🟢 Native<br>`SetPosition` command | 🟢 Native<br>position command | 🟢 Native<br>position request |
 | `seeked` | 🟢 Native<br>`Seeked` signal | 🔴 Unimplemented | 🔴 Unimplemented |
+
+### URI Activation
+
+URI activation is a split responsibility:
+
+- On Linux, `on_open_uri` is exposed natively through MPRIS.
+- On macOS and Windows, the library can help the current process open a URI.
+- Registering a custom protocol and receiving system URI activation still belongs to the host application.
+
+The scheme name is host-defined. `aionowplaying` does not require the public scheme to be `aionowplaying`.
+
+Platform docs:
+
+- [`docs/platform-uri-activation.rst`](docs/platform-uri-activation.rst)
+- [`docs/platform-uri-activation-macos.rst`](docs/platform-uri-activation-macos.rst)
+- [`docs/platform-uri-activation-windows.rst`](docs/platform-uri-activation-windows.rst)
 
 ### Property APIs
 
@@ -173,7 +194,7 @@ uv run python scripts/build_site.py
 
 The generated site is written to `dist/`.
 
-GitHub Pages is configured in [.github/workflows/pages.yml](.github/workflows/pages.yml) and publishes the site automatically on pushes to `develop`.
+GitHub Pages is configured in [.github/workflows/pages.yml](.github/workflows/pages.yml) and publishes the site automatically on pushes to `master`.
 
 ## License
 
@@ -198,7 +219,7 @@ If you find a bug or have a feature request:
 
 ### Pull Requests
 
-1. Fork the repository and create a feature branch from `main`
+1. Fork the repository and create a feature branch from `master`
 2. Run tests locally: `uv run pytest -v`
 3. Ensure code follows project conventions
 4. Write clear commit messages

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,13 @@ import asyncio
 from datetime import timedelta
 from aionowplaying import NowPlaying
 
-# 创建播放器并设置元数据和回调
+# 将媒体回调绑定到你的应用逻辑。
+def handle_play():
+    pass
+
+def handle_pause():
+    pass
+
 player = NowPlaying(
     "My Player",
     metadata={
@@ -49,9 +55,8 @@ player = NowPlaying(
         "album": "专辑",
         "duration": timedelta(minutes=3, seconds=30),
     },
-    on_play=lambda: my_player.play(),
-    on_pause=lambda: my_player.pause(),
-    on_next=lambda: my_player.next(),
+    on_play=handle_play,
+    on_pause=handle_pause,
 )
 
 # 播放过程中更新元数据
@@ -125,9 +130,25 @@ class MyPlayer(BaseInterface):
 | 方法 | Linux (MPRIS2) | macOS | Windows |
 | --- | --- | --- | --- |
 | `on_seek` | 🟢 原生实现<br>offset seek | 🟡 部分实现<br>绝对位置 | 🟡 部分实现<br>绝对位置 |
-| `on_open_uri` | 🟢 原生实现<br>`OpenUri` 命令 | 🔴 未实现 | 🔴 未实现 |
+| `on_open_uri` | 🟢 原生实现<br>`OpenUri` 命令 | 🟡 库级辅助<br>由当前进程打开 URI | 🟡 库级辅助<br>由当前进程打开 URI |
 | `on_set_position` | 🟢 原生实现<br>`SetPosition` 命令 | 🟢 原生实现<br>位置命令 | 🟢 原生实现<br>位置请求 |
 | `seeked` | 🟢 原生实现<br>`Seeked` 信号 | 🔴 未实现 | 🔴 未实现 |
+
+### URI 激活
+
+URI 激活是一个分工明确的能力：
+
+- 在 Linux 上，`on_open_uri` 由 MPRIS 原生暴露。
+- 在 macOS 和 Windows 上，库可以帮助当前进程主动打开 URI。
+- 但注册自定义协议并接收系统 URI 激活，仍然需要宿主应用来完成。
+
+协议名称由宿主应用自行决定，`aionowplaying` 不强制公共 scheme 使用 `aionowplaying`。
+
+平台文档：
+
+- [`docs/platform-uri-activation.rst`](docs/platform-uri-activation.rst)
+- [`docs/platform-uri-activation-macos.rst`](docs/platform-uri-activation-macos.rst)
+- [`docs/platform-uri-activation-windows.rst`](docs/platform-uri-activation-windows.rst)
 
 ### 属性接口
 
@@ -183,7 +204,7 @@ uv run pytest -v
 
 ### 提交 Pull Request
 
-1. Fork 仓库并从 `main` 创建功能分支
+1. Fork 仓库并从 `master` 创建功能分支
 2. 本地运行测试：`uv run pytest -v`
 3. 确保代码符合项目规范
 4. 提交信息清晰明了

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,4 +8,5 @@ A cross-platform Now Playing client.
    :caption: Contents:
 
    quickstart
+   platform-uri-activation
    api

--- a/docs/platform-uri-activation-macos.rst
+++ b/docs/platform-uri-activation-macos.rst
@@ -1,0 +1,84 @@
+macOS URI Activation
+====================
+
+This page shows the host-side part of URI activation on macOS.
+
+Why the library cannot do this alone
+------------------------------------
+
+``aionowplaying`` is a library, not a macOS application bundle. URI activation
+on macOS is delivered to an installed ``.app`` that registers a URL type in its
+``Info.plist``. Without that host bundle, there is nowhere for the operating
+system to send the activation event.
+
+That means the library can help with opening a URI from the current process, but
+the host application must still register the scheme and receive the activated
+URI.
+
+What the host needs to do
+-------------------------
+
+The host application must:
+
+* choose a custom scheme
+* add the scheme to ``CFBundleURLTypes`` in ``Info.plist``
+* receive the URL in the app delegate or scene lifecycle
+* forward the URI to playback logic
+
+Minimal reference
+-----------------
+
+The example below uses a host-defined scheme such as ``myplayer://``. Replace
+the scheme name with one that belongs to your application.
+
+.. code-block:: swift
+
+    import Cocoa
+
+    @main
+    class AppDelegate: NSObject, NSApplicationDelegate {
+        private let player = PlayerController()
+
+        func application(_ application: NSApplication,
+                         open urls: [URL]) {
+            for url in urls {
+                handleActivatedURI(url.absoluteString)
+            }
+        }
+
+        private func handleActivatedURI(_ uri: String) {
+            player.handleActivatedURI(uri)
+        }
+    }
+
+.. code-block:: xml
+
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>com.example.myplayer</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>myplayer</string>
+        </array>
+      </dict>
+    </array>
+
+Returning the URI to player logic
+---------------------------------
+
+Keep URI parsing out of the app delegate when possible. A small player-facing
+method keeps the activation path simple:
+
+.. code-block:: swift
+
+    final class PlayerController {
+        func handleActivatedURI(_ uri: String) {
+            // Parse the URI and decide whether to open, queue, or play it.
+            print("Activated URI:", uri)
+        }
+    }
+
+If your player already has a command handler, route the URI there instead of
+duplicating playback rules in the macOS lifecycle code.

--- a/docs/platform-uri-activation-windows.rst
+++ b/docs/platform-uri-activation-windows.rst
@@ -1,0 +1,81 @@
+Windows URI Activation
+======================
+
+This page shows the host-side part of URI activation on Windows.
+
+Why the library cannot do this alone
+------------------------------------
+
+``aionowplaying`` can help a running process open a URI, but Windows URI
+activation is owned by the installed host application. The operating system
+delivers custom-scheme launches to the app registration, packaged app manifest,
+or desktop installation entry. A standalone library does not receive those
+events on its own.
+
+What the host needs to do
+-------------------------
+
+The host application must:
+
+* choose a custom scheme
+* register that scheme for the app
+* read the activation URI from launch data or command-line arguments
+* forward the URI to playback logic
+
+Minimal reference
+-----------------
+
+The example below uses a host-defined scheme such as ``myplayer://``. Replace
+the scheme name with one that belongs to your application.
+
+Packaged apps can read activation arguments from the app activation event. For a
+desktop-style host, the same URI can also be forwarded through the command line
+when the app is launched by the shell.
+
+.. code-block:: python
+
+    import sys
+
+    class PlayerController:
+        def handle_activated_uri(self, uri: str) -> None:
+            # Parse the URI and decide whether to open, queue, or play it.
+            print(f"Activated URI: {uri}")
+
+    def main() -> None:
+        player = PlayerController()
+
+        # Example command-line activation:
+        # myplayer://open?target=https%3A%2F%2Fexample.com%2Ftrack
+        if len(sys.argv) > 1 and sys.argv[1].startswith("myplayer://"):
+            player.handle_activated_uri(sys.argv[1])
+
+    if __name__ == "__main__":
+        main()
+
+.. code-block:: xml
+
+    <Applications>
+      <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="Windows.FullTrustApplication">
+        <Extensions>
+          <uap:Extension Category="windows.protocol">
+            <uap:Protocol Name="myplayer" />
+          </uap:Extension>
+        </Extensions>
+      </Application>
+    </Applications>
+
+Returning the URI to player logic
+---------------------------------
+
+The host should normalize the URI first, then hand it to the player layer in a
+single place:
+
+.. code-block:: python
+
+    def handle_activated_uri(player, uri: str) -> None:
+        # Keep the activation bridge thin.
+        player.handle_activated_uri(uri)
+
+If your app uses a dedicated playback service, let the host code call that
+service directly. The important part is that activation handling stays outside
+``aionowplaying`` while the playback decision stays inside your player layer.

--- a/docs/platform-uri-activation.rst
+++ b/docs/platform-uri-activation.rst
@@ -1,0 +1,54 @@
+URI Activation Overview
+=======================
+
+``aionowplaying`` can help a running process open a URI, but it does not turn
+the library into a desktop app host. URI activation is a two-part problem:
+
+1. The current process may open a URI on purpose.
+2. The host application must register a custom scheme and receive the activated
+   URI from the operating system.
+
+The library can support the first part directly. The second part belongs to the
+host application, because the OS delivers URI activation to an installed app or
+bundle, not to a standalone Python library.
+
+What the library can do
+-----------------------
+
+The library can expose a small API for opening URIs from the current process.
+That is useful when your player wants to hand a link to the platform default
+handler or open a resource in the system browser.
+
+What the host must do
+---------------------
+
+The host application is still responsible for:
+
+* choosing a custom scheme
+* registering that scheme with the OS
+* receiving the activation event or launch arguments
+* parsing the URI
+* forwarding the URI to playback logic
+
+The scheme is host-defined. ``aionowplaying`` does not require ``aionowplaying``
+as the public scheme name. A host can use values such as ``myplayer://`` or any
+other scheme that fits its product.
+
+How the pieces fit together
+---------------------------
+
+The most practical shape is:
+
+* ``aionowplaying`` provides the media abstraction and a helper for opening a
+  URI from the current process.
+* The host registers a custom scheme and handles activation.
+* The host passes the activated URI into the player layer, which can then decide
+  whether to open it, queue it, or play it directly.
+
+For platform examples, see:
+
+.. toctree::
+   :maxdepth: 1
+
+   platform-uri-activation-macos
+   platform-uri-activation-windows

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,6 +3,11 @@ Quick Start
 
 This section will guide you through the basic usage of aionowplaying.
 
+If you need URI support, start with the platform overview at
+:doc:`platform-uri-activation`. That page explains the split between
+"open a URI from the current process" and "receive URI activation from the
+operating system", then links to the macOS and Windows host examples.
+
 Installation
 ------------
 
@@ -29,7 +34,13 @@ Use the ``NowPlaying`` class for a simplified interface:
     from datetime import timedelta
     from aionowplaying import NowPlaying
 
-    # Create player with metadata and callbacks
+    # Wire media callbacks to your own application logic.
+    def handle_play():
+        pass
+
+    def handle_pause():
+        pass
+
     player = NowPlaying(
         "My Player",
         metadata={
@@ -38,9 +49,8 @@ Use the ``NowPlaying`` class for a simplified interface:
             "album": "Album",
             "duration": timedelta(minutes=3, seconds=30),
         },
-        on_play=lambda: my_player.play(),
-        on_pause=lambda: my_player.pause(),
-        on_next=lambda: my_player.next(),
+        on_play=handle_play,
+        on_pause=handle_pause,
     )
 
     # Update metadata during playback
@@ -62,6 +72,12 @@ To run the backend in the background, use ``asyncio.ensure_future``:
     from datetime import timedelta
     from aionowplaying import NowPlaying
 
+    def handle_play():
+        pass
+
+    def handle_pause():
+        pass
+
     async def main():
         player = NowPlaying(
             "My Player",
@@ -70,8 +86,8 @@ To run the backend in the background, use ``asyncio.ensure_future``:
                 "artist": ["Artist"],
                 "duration": timedelta(minutes=3),
             },
-            on_play=lambda: my_player.play(),
-            on_pause=lambda: my_player.pause(),
+            on_play=handle_play,
+            on_pause=handle_pause,
         )
 
         # Start in background
@@ -127,23 +143,24 @@ You can register callbacks for media control events:
 
 .. code-block:: python
 
-    from aionowplaying import NowPlaying, LoopStatus
+    from aionowplaying import NowPlaying
+
+    def handle_play():
+        pass
+
+    def handle_pause():
+        pass
 
     player = NowPlaying(
         "My Player",
-        on_play=lambda: player.play(),
-        on_pause=lambda: player.pause(),
-        on_next=lambda: player.next_track(),
-        on_previous=lambda: player.previous_track(),
-        on_stop=lambda: player.stop(),
-        on_seek=lambda pos: player.seek(pos),  # pos is timedelta
-        on_volume=lambda vol: player.set_volume(vol),  # vol is float 0.0-1.0
-        on_shuffle=lambda enabled: player.set_shuffle(enabled),  # enabled is bool
-        on_loop=lambda status: player.set_loop(status),  # status is LoopStatus
+        on_play=handle_play,
+        on_pause=handle_pause,
     )
 
-Capabilities are automatically inferred from the callbacks you provide. For example,
-if you provide ``on_play``, ``CanPlay`` will be set to ``True`` automatically.
+Supported capability flags are derived from the callbacks the backend knows how to
+surface. For example, providing ``on_play`` can enable the corresponding play
+capability, but callback names are not universally or automatically mapped to
+every possible capability.
 
 Advanced Usage
 --------------
@@ -167,3 +184,14 @@ For fine-grained control, inherit from ``BaseInterface``:
 
     The ``select_interface()`` function and ``NowPlayingInterface`` alias are deprecated.
     Use ``NowPlaying`` instead.
+
+URI Activation
+--------------
+
+``aionowplaying`` can help your current process open a URI, but it cannot
+register a URL scheme or receive external URI activations by itself. Host
+applications must define their own custom scheme, register it with the
+operating system, and forward activated URIs back into player logic.
+
+For the cross-platform overview and host-specific examples, see
+:doc:`platform-uri-activation`.

--- a/docs/superpowers/plans/2026-04-21-openuri-uri-activation-implementation.md
+++ b/docs/superpowers/plans/2026-04-21-openuri-uri-activation-implementation.md
@@ -1,0 +1,568 @@
+# OpenUri And URI Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 macOS 和 Windows 补齐本地 `OpenUri` 能力，并新增宿主 URI 激活示例文档与 README/Sphinx 引用入口。
+
+**Architecture:** 代码实现分为两部分：一是平台接口层在 macOS 和 Windows 上实现“当前进程主动打开 URI”；二是文档层新增宿主接入示例页面，说明协议注册与 URI 激活为何不能由库单独完成。文档入口统一从 `README.md`、`README.zh-CN.md` 与 Sphinx 目录树暴露。
+
+**Tech Stack:** Python, PyObjC AppKit/Foundation, Windows URI launch APIs, pytest, Sphinx, Markdown, reStructuredText
+
+---
+
+## File Structure
+
+- Modify: `src/aionowplaying/interface/macos.py`
+  用 `NSWorkspace` 实现 macOS 平台的本地 URI 打开能力。
+- Modify: `src/aionowplaying/interface/windows.py`
+  实现 Windows 平台的本地 URI 打开能力，优先走官方 URI 启动 API，必要时保留桌面兼容路径。
+- Create: `tests/test_open_uri_helpers.py`
+  放置跨平台、可 mock 的 `OpenUri` 行为测试，避免依赖真实桌面环境。
+- Modify: `README.md`
+  新增 OpenUri 限制说明和示例文档入口。
+- Modify: `README.zh-CN.md`
+  新增中文版本的 OpenUri 限制说明和示例文档入口。
+- Modify: `docs/index.rst`
+  把新示例页面挂入 Sphinx 目录树。
+- Modify: `docs/quickstart.rst`
+  增加到平台 URI 激活说明页的导航。
+- Create: `docs/platform-uri-activation.rst`
+  作为平台 URI 接入总览页，说明库职责与宿主职责边界。
+- Create: `docs/platform-uri-activation-macos.rst`
+  macOS 宿主接入示例页面。
+- Create: `docs/platform-uri-activation-windows.rst`
+  Windows 宿主接入示例页面。
+
+### Task 1: Add Testable OpenUri Behavior For macOS
+
+**Files:**
+- Modify: `src/aionowplaying/interface/macos.py`
+- Test: `tests/test_open_uri_helpers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from aionowplaying.interface.macos import MacOSInterface
+
+
+class _FakeWorkspace:
+    def __init__(self):
+        self.opened = []
+
+    def openURL_(self, url):
+        self.opened.append(url)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_macos_on_open_uri_uses_workspace(monkeypatch):
+    opened = {"url": None}
+
+    class _FakeNSURL:
+        @staticmethod
+        def URLWithString_(value):
+            opened["url"] = value
+            return f"NSURL({value})"
+
+    workspace = _FakeWorkspace()
+    monkeypatch.setattr("aionowplaying.interface.macos.NSURL", _FakeNSURL)
+    monkeypatch.setattr(
+        "aionowplaying.interface.macos.NSWorkspace",
+        type("NSWorkspace", (), {"sharedWorkspace": staticmethod(lambda: workspace)}),
+    )
+
+    it = MacOSInterface("test")
+    await it.on_open_uri("https://example.com/song.mp3")
+
+    assert opened["url"] == "https://example.com/song.mp3"
+    assert workspace.opened == ["NSURL(https://example.com/song.mp3)"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py::test_macos_on_open_uri_uses_workspace -v`
+Expected: FAIL with `AttributeError` or equivalent because `MacOSInterface` does not implement `on_open_uri`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+from AppKit import NSImage, NSWorkspace
+
+
+class MacOSInterface(BaseInterface):
+    ...
+
+    async def on_open_uri(self, uri: str):
+        url = NSURL.URLWithString_(uri)
+        if url is None:
+            raise ValueError(f"Invalid URI: {uri}")
+
+        workspace = NSWorkspace.sharedWorkspace()
+        if not workspace.openURL_(url):
+            raise RuntimeError(f"Failed to open URI: {uri}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py::test_macos_on_open_uri_uses_workspace -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_open_uri_helpers.py src/aionowplaying/interface/macos.py
+git commit -m "feat: 增加 macos openuri 实现" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 2: Add Testable OpenUri Behavior For Windows
+
+**Files:**
+- Modify: `src/aionowplaying/interface/windows.py`
+- Test: `tests/test_open_uri_helpers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+
+from aionowplaying.interface.windows import WindowsInterface
+
+
+@pytest.mark.asyncio
+async def test_windows_on_open_uri_calls_opener(monkeypatch):
+    called = {"uri": None}
+
+    def fake_open_uri(uri):
+        called["uri"] = uri
+
+    monkeypatch.setattr(
+        "aionowplaying.interface.windows._open_uri_with_system",
+        fake_open_uri,
+    )
+
+    it = WindowsInterface("test")
+    await it.on_open_uri("https://example.com/song.mp3")
+
+    assert called["uri"] == "https://example.com/song.mp3"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py::test_windows_on_open_uri_calls_opener -v`
+Expected: FAIL because `_open_uri_with_system` or `on_open_uri` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def _open_uri_with_system(uri: str):
+    import webbrowser
+
+    if not webbrowser.open(uri):
+        raise RuntimeError(f"Failed to open URI: {uri}")
+
+
+class WindowsInterface(BaseInterface):
+    ...
+
+    async def on_open_uri(self, uri: str):
+        _open_uri_with_system(uri)
+```
+
+说明：
+
+- 第一版实现优先保证行为可测试和可落地。
+- 如果执行阶段确认 `winrt` 的 `Launcher.LaunchUriAsync` 更适合且项目运行环境稳定，可在实现阶段把 helper 改成官方 API，并保留测试边界不变。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py::test_windows_on_open_uri_calls_opener -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_open_uri_helpers.py src/aionowplaying/interface/windows.py
+git commit -m "feat: 增加 windows openuri 实现" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 3: Add Error-Handling And Basic Validation Tests
+
+**Files:**
+- Modify: `src/aionowplaying/interface/macos.py`
+- Modify: `src/aionowplaying/interface/windows.py`
+- Test: `tests/test_open_uri_helpers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import pytest
+
+from aionowplaying.interface.macos import MacOSInterface
+from aionowplaying.interface.windows import _open_uri_with_system
+
+
+@pytest.mark.asyncio
+async def test_macos_on_open_uri_rejects_invalid_url(monkeypatch):
+    class _FakeNSURL:
+        @staticmethod
+        def URLWithString_(_value):
+            return None
+
+    monkeypatch.setattr("aionowplaying.interface.macos.NSURL", _FakeNSURL)
+    it = MacOSInterface("test")
+
+    with pytest.raises(ValueError, match="Invalid URI"):
+        await it.on_open_uri("not a uri")
+
+
+def test_windows_open_uri_raises_when_system_opener_fails(monkeypatch):
+    monkeypatch.setattr("webbrowser.open", lambda _uri: False)
+
+    with pytest.raises(RuntimeError, match="Failed to open URI"):
+        _open_uri_with_system("https://example.com")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py -v`
+Expected: FAIL because invalid URI and failure-path handling are not complete yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+async def on_open_uri(self, uri: str):
+    if not uri:
+        raise ValueError("Invalid URI: empty string")
+    ...
+
+
+def _open_uri_with_system(uri: str):
+    if not uri:
+        raise ValueError("Invalid URI: empty string")
+    import webbrowser
+    if not webbrowser.open(uri):
+        raise RuntimeError(f"Failed to open URI: {uri}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_open_uri_helpers.py src/aionowplaying/interface/macos.py src/aionowplaying/interface/windows.py
+git commit -m "test: 补充 openuri 错误处理覆盖" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 4: Add Sphinx Overview Page For URI Activation
+
+**Files:**
+- Create: `docs/platform-uri-activation.rst`
+- Modify: `docs/index.rst`
+- Modify: `docs/quickstart.rst`
+
+- [ ] **Step 1: Write the failing doc references**
+
+在 `docs/index.rst` 的 `toctree` 中预先加入：
+
+```rst
+   platform-uri-activation
+```
+
+并在 `docs/quickstart.rst` 追加：
+
+```rst
+URI Activation
+--------------
+
+For macOS and Windows host integration examples, see :doc:`platform-uri-activation`.
+```
+
+Expected: 文档构建失败，因为 `platform-uri-activation.rst` 尚不存在。
+
+- [ ] **Step 2: Run docs build to verify it fails**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: FAIL with missing document `platform-uri-activation`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+创建 `docs/platform-uri-activation.rst`：
+
+```rst
+URI Activation And Host Integration
+===================================
+
+``aionowplaying`` can expose a cross-platform ``on_open_uri`` abstraction, but host
+URI activation is still the responsibility of the host application.
+
+This page explains the boundary:
+
+- Opening a URI from within the current process
+- Receiving a URI from the operating system via a registered scheme
+
+Platform-specific examples:
+
+- :doc:`platform-uri-activation-macos`
+- :doc:`platform-uri-activation-windows`
+```
+
+- [ ] **Step 4: Run docs build to verify it passes**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/index.rst docs/quickstart.rst docs/platform-uri-activation.rst
+git commit -m "docs: 增加 uri 激活总览页" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 5: Add macOS Host Integration Example Page
+
+**Files:**
+- Create: `docs/platform-uri-activation-macos.rst`
+- Modify: `docs/platform-uri-activation.rst`
+
+- [ ] **Step 1: Write the failing doc reference**
+
+在 `docs/platform-uri-activation.rst` 中加入：
+
+```rst
+- :doc:`platform-uri-activation-macos`
+```
+
+Expected: 构建失败，因为目标页面不存在。
+
+- [ ] **Step 2: Run docs build to verify it fails**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: FAIL with missing document `platform-uri-activation-macos`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+创建 `docs/platform-uri-activation-macos.rst`：
+
+```rst
+macOS Host Integration Example
+==============================
+
+Why the library alone is not enough
+-----------------------------------
+
+``MPNowPlayingInfoCenter`` and ``MPRemoteCommandCenter`` do not register URL schemes
+or receive app activation payloads. The host app must do that.
+
+What the host app needs to do
+-----------------------------
+
+1. Register a custom URL scheme in ``Info.plist`` via ``CFBundleURLTypes``.
+2. Receive the incoming URL in the AppKit lifecycle.
+3. Parse the URL and hand the target URI back to the playback layer.
+
+Example
+-------
+
+.. code-block:: python
+
+    from Foundation import NSURL
+
+    def handle_incoming_url(raw_url: str, player):
+        url = NSURL.URLWithString_(raw_url)
+        if url is None:
+            raise ValueError(f"Invalid URL: {raw_url}")
+
+        # Replace this parser with your host application's own scheme contract.
+        target = raw_url
+        return player.load_from_uri(target)
+```
+
+- [ ] **Step 4: Run docs build to verify it passes**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/platform-uri-activation.rst docs/platform-uri-activation-macos.rst
+git commit -m "docs: 增加 macos uri 激活示例" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 6: Add Windows Host Integration Example Page
+
+**Files:**
+- Create: `docs/platform-uri-activation-windows.rst`
+- Modify: `docs/platform-uri-activation.rst`
+
+- [ ] **Step 1: Write the failing doc reference**
+
+在 `docs/platform-uri-activation.rst` 中加入：
+
+```rst
+- :doc:`platform-uri-activation-windows`
+```
+
+Expected: 构建失败，因为目标页面不存在。
+
+- [ ] **Step 2: Run docs build to verify it fails**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: FAIL with missing document `platform-uri-activation-windows`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+创建 `docs/platform-uri-activation-windows.rst`：
+
+```rst
+Windows Host Integration Example
+================================
+
+Why the library alone is not enough
+-----------------------------------
+
+``SystemMediaTransportControls`` does not register URI schemes or deliver URI
+activation events. The host application must own that part.
+
+What the host app needs to do
+-----------------------------
+
+1. Register a custom protocol handler.
+2. Read the activation URI from the host's activation payload or command-line arguments.
+3. Parse the URI and hand the target back to the playback layer.
+
+Example
+-------
+
+.. code-block:: python
+
+    import sys
+
+    def handle_protocol_launch(player):
+        if len(sys.argv) < 2:
+            return None
+
+        raw_url = sys.argv[1]
+        target = raw_url
+        return player.load_from_uri(target)
+```
+
+- [ ] **Step 4: Run docs build to verify it passes**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/platform-uri-activation.rst docs/platform-uri-activation-windows.rst
+git commit -m "docs: 增加 windows uri 激活示例" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 7: Add README Entry Points For The New Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+- [ ] **Step 1: Write the failing content expectation**
+
+在两个 README 中都新增一个独立小节，要求至少包含以下要点：
+
+- `on_open_uri` 在 Linux/macOS/Windows 上的能力差异
+- macOS / Windows 上“本地打开 URI”和“宿主接收 URI 激活”的区别
+- 指向新的文档页面链接
+
+Expected: 当前 README 不满足这些内容要求。
+
+- [ ] **Step 2: Verify current README is missing the content**
+
+Run: `rg -n "URI activation|宿主|on_open_uri|platform-uri-activation" README.md README.zh-CN.md`
+Expected: README 中没有指向新文档的入口。
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `README.md` 中增加类似内容：
+
+```md
+## URI Activation
+
+`on_open_uri` is natively exposed through MPRIS on Linux. On macOS and Windows,
+the library can open a URI from the current process, but registering a custom
+scheme and receiving activation payloads must be implemented by the host app.
+
+See:
+
+- `docs/platform-uri-activation.rst`
+- `docs/platform-uri-activation-macos.rst`
+- `docs/platform-uri-activation-windows.rst`
+```
+
+在 `README.zh-CN.md` 中增加对应中文说明：
+
+```md
+## URI 激活
+
+Linux 上的 `on_open_uri` 由 MPRIS 原生暴露。macOS 和 Windows 上，库可以提供
+“当前进程主动打开 URI”的能力，但“注册协议并接收系统激活参数”仍需由宿主应用完成。
+
+参见：
+
+- `docs/platform-uri-activation.rst`
+- `docs/platform-uri-activation-macos.rst`
+- `docs/platform-uri-activation-windows.rst`
+```
+
+- [ ] **Step 4: Verify the new content is present**
+
+Run: `rg -n "URI Activation|URI 激活|platform-uri-activation" README.md README.zh-CN.md`
+Expected: PASS with new headings and links.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md README.zh-CN.md
+git commit -m "docs: 增加 openuri 与 uri 激活说明" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```
+
+### Task 8: Run Final Verification Across Tests And Docs
+
+**Files:**
+- Test: `tests/test_open_uri_helpers.py`
+- Test: `docs/platform-uri-activation.rst`
+- Test: `docs/platform-uri-activation-macos.rst`
+- Test: `docs/platform-uri-activation-windows.rst`
+- Test: `README.md`
+- Test: `README.zh-CN.md`
+
+- [ ] **Step 1: Run the targeted Python tests**
+
+Run: `uv run pytest tests/test_open_uri_helpers.py -v`
+Expected: PASS
+
+- [ ] **Step 2: Run the existing interface tests that could regress**
+
+Run: `uv run pytest tests/test_macos_interface.py tests/test_windows_interface.py -v`
+Expected: PASS on supported platforms or SKIPPED where the platform is unavailable.
+
+- [ ] **Step 3: Build the docs**
+
+Run: `sphinx-build -b html docs docs/_build/html`
+Expected: PASS
+
+- [ ] **Step 4: Verify README and docs entry points**
+
+Run: `rg -n "platform-uri-activation" README.md README.zh-CN.md docs/index.rst docs/quickstart.rst`
+Expected: PASS with all expected references present.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aionowplaying/interface/macos.py src/aionowplaying/interface/windows.py tests/test_open_uri_helpers.py README.md README.zh-CN.md docs/index.rst docs/quickstart.rst docs/platform-uri-activation.rst docs/platform-uri-activation-macos.rst docs/platform-uri-activation-windows.rst
+git commit -m "feat: 完善 openuri 与宿主 uri 激活文档" --author="Codex (gpt-5) <noreply@email.openai.com>"
+```

--- a/docs/superpowers/specs/2026-04-21-uri-activation-design.md
+++ b/docs/superpowers/specs/2026-04-21-uri-activation-design.md
@@ -1,0 +1,521 @@
+# aionowplaying URI 激活与 OpenUri 跨平台方案文档
+
+**日期**: 2026-04-21
+**作者**: Codex + Bruce
+**状态**: 草案
+
+## 背景
+
+当前项目在 Linux 平台通过 MPRIS2 暴露 `OpenUri`，对应 D-Bus `org.mpris.MediaPlayer2.Player.OpenUri` 方法。
+
+在 macOS 和 Windows 平台，项目已经分别接入：
+
+- macOS: `MPNowPlayingInfoCenter` + `MPRemoteCommandCenter`
+- Windows: `SystemMediaTransportControls`（SMTC）
+
+issue #17 关注的问题，是在 macOS 和 Windows 上如何补齐与 `OpenUri` 语义接近的能力，以及宿主应用如何真正“接收 URI 并处理”。
+
+## 问题定义
+
+这里实际上存在两个容易混淆但必须拆开的能力：
+
+### 1. 应用内打开 URI
+
+指库或宿主应用在本地代码中收到一个 URI 字符串后，主动调用系统 API 打开它，例如：
+
+- macOS: `NSWorkspace.open(_:)`
+- Windows: `Launcher.LaunchUriAsync` 或 `ShellExecute`
+
+这类能力的本质是“应用主动发起打开动作”。
+
+### 2. 应用被外部 URI 激活
+
+指系统或外部应用通过类似 `myplayer://...` 的协议唤起宿主应用，并把 URI 作为参数传入。
+
+这类能力的本质是“应用成为 URI scheme handler，并在启动或激活时接收 URI”。
+
+`OpenUri` 的跨平台实现如果只做到第 1 类能力，只能支持“本地调用打开 URI”；如果要支持“应用接受这个 URI”，就必须补上第 2 类能力。
+
+## 官方能力边界
+
+### macOS: MPNowPlaying / MPRemoteCommandCenter
+
+Apple 官方文档中：
+
+- `MPNowPlayingInfoCenter` 的职责是展示当前播放信息
+- `MPRemoteCommandCenter` 的职责是接收系统媒体控制命令
+
+它们支持的命令集中在：
+
+- 播放 / 暂停 / 停止
+- 上一首 / 下一首
+- 播放位置变更
+- 播放速率
+- 循环 / 随机
+- 评分、喜欢、不喜欢、书签等媒体交互
+
+没有 `OpenUri`、`OpenURL` 或“让系统媒体中心把一个 URI 传给应用”的命令入口。
+
+因此，macOS 上不能通过 `MPNowPlaying` 体系直接承载 `OpenUri`。
+
+### Windows: SMTC
+
+Microsoft 官方文档中，`SystemMediaTransportControls` 也是媒体控制入口，而不是 URI 激活入口。
+
+它支持的能力集中在：
+
+- 播放 / 暂停 / 停止
+- 上一首 / 下一首
+- 快进 / 快退
+- 播放位置
+- 速率、循环、随机
+- 元数据与时间线展示
+
+同样没有“OpenUri”类按钮、事件或激活路径。
+
+因此，Windows 上也不能通过 SMTC 直接承载 `OpenUri`。
+
+## 核心结论
+
+macOS 的 `MPNowPlaying` 与 Windows 的 `SMTC` 都不能直接实现“系统媒体接口向应用下发 OpenUri”。
+
+如果目标是跨平台补齐 `OpenUri` 能力，必须采用“双层设计”：
+
+1. 媒体控制层继续使用各平台现有能力
+2. URI 激活层由宿主应用单独实现
+
+也就是说：
+
+- `aionowplaying` 可以定义统一的 `OpenUri` 抽象
+- 但真正接收 URI 的动作，不能依赖 `MPNowPlaying` 或 `SMTC`
+- 它必须由宿主应用注册协议并接收系统激活事件
+
+## 目标
+
+本方案希望实现以下能力：
+
+1. 在 macOS 和 Windows 上提供与 Linux `OpenUri` 语义尽量一致的抽象
+2. 允许宿主应用主动打开 URI
+3. 允许宿主应用被外部 URI scheme 激活
+4. 为无法由库独立完成的宿主集成部分提供 macOS 与 Windows 的实现示例
+5. 在 README 与 Sphinx 文档中引用单独的示例页面，降低接入门槛
+6. 保持 `aionowplaying` 作为跨平台媒体抽象层，而不是直接演变成完整桌面应用框架
+
+## 非目标
+
+本次方案不包含以下范围：
+
+- 不在 macOS 或 Windows 上模拟完整 MPRIS D-Bus 服务
+- 不要求 `MPNowPlaying` 或 `SMTC` 原生支持 `OpenUri`
+- 不在库内部直接承担应用打包、安装器、注册表写入或 `.app` bundle 生成
+- 不定义完整的 URI 播放协议生态，只定义最小可用方案
+- 不要求库直接替代宿主应用完成最终安装或系统注册
+
+## 方案候选
+
+### 方案 A: 只实现本地 `open_uri()`
+
+做法：
+
+- macOS 平台在 `MacOSInterface` 中调用 `NSWorkspace.open`
+- Windows 平台在 `WindowsInterface` 中调用系统 URI 打开 API
+- 不提供“外部 URI 激活应用”的设计
+
+优点：
+
+- 实现最简单
+- 对现有代码改动最小
+- 可以快速关闭 issue #17 中“本地打开 URI”的部分诉求
+
+缺点：
+
+- 无法让应用真正接收外部 URI
+- 无法支持宿主自定义 scheme 深链
+- 与“应用接受这个 URI”的目标不一致
+
+适用场景：
+
+- 只需要在应用内部把 URI 交给系统默认处理器
+
+### 方案 B: 库层定义统一抽象，宿主应用负责 URI 激活
+
+做法：
+
+- `aionowplaying` 保留统一的 `on_open_uri(uri)` 抽象
+- 宿主应用负责注册自己的 URI scheme
+- 宿主应用在被系统激活时解析 URI
+- 宿主应用将目标 URI 再交给自己的播放逻辑或库层回调
+
+优点：
+
+- 角色边界清晰
+- 与当前项目“库而非应用”的定位一致
+- macOS 和 Windows 都有成熟官方机制支撑
+- 可以同时支持“本地打开 URI”和“外部唤起应用”
+
+缺点：
+
+- 宿主应用需要额外实现协议注册和激活处理
+- 库侧只能定义契约，不能单独完成端到端体验
+
+适用场景：
+
+- 当前仓库继续保持为跨平台媒体控制库
+
+### 方案 C: 在库外提供一个官方宿主适配器或示例应用
+
+做法：
+
+- 在方案 B 的基础上
+- 额外提供示例宿主工程，演示 macOS `.app` 和 Windows 桌面应用如何接收 URI
+
+优点：
+
+- 文档和示例更完整
+- 降低宿主接入门槛
+
+缺点：
+
+- 会明显扩大当前仓库维护范围
+- 需要处理平台打包、签名、分发等额外问题
+
+适用场景：
+
+- 后续希望把项目推广成“库 + 参考宿主”的组合方案
+
+## 推荐方案
+
+采用方案 B。
+
+原因：
+
+- 它最符合 `aionowplaying` 当前定位
+- 它把“媒体控制能力”和“应用激活能力”清晰拆分
+- 它既能覆盖 issue #17，也能为后续深链、第三方唤起、播放器接管协议留出空间
+- 它不要求伪造 `MPNowPlaying`/`SMTC` 不具备的系统能力
+
+## 推荐架构
+
+### 分层模型
+
+建议将跨平台能力明确分成三层：
+
+1. 系统媒体层
+   - Linux: MPRIS2
+   - macOS: `MPNowPlayingInfoCenter` / `MPRemoteCommandCenter`
+   - Windows: `SMTC`
+
+2. URI 打开层
+   - 提供“当前进程主动打开 URI”的能力
+   - macOS 使用 `NSWorkspace`
+   - Windows 使用官方 URI 启动 API
+
+3. URI 激活层
+   - 由宿主应用注册并接收自定义 scheme
+   - 接收到 URI 后交给业务逻辑解析
+
+### 责任边界
+
+`aionowplaying` 负责：
+
+- 定义统一抽象接口
+- 为平台接口提供本地 `open_uri` 能力
+- 允许宿主把“收到的 URI”注入到播放器逻辑中
+- 提供宿主接入示例文档与参考代码片段
+
+宿主应用负责：
+
+- 注册 URI scheme
+- 接收系统激活事件
+- 解析 URI
+- 决定是交给系统默认应用打开，还是在应用内加载播放
+
+## 文档与示例交付要求
+
+对于无法由库独立完成的能力，本方案要求同时提供“说明文档 + 平台示例”。
+
+### 交付内容
+
+至少增加两类单独页面：
+
+1. macOS 宿主接入示例页
+2. Windows 宿主接入示例页
+
+每个页面都应独立成文，而不是只在 README 中放零散片段。
+
+### 页面内容要求
+
+每个示例页至少应包含：
+
+- 该平台上为什么这部分能力不能由库单独完成
+- 宿主应用需要负责哪些事情
+- 最小可运行示例或接近可运行的参考代码
+- URI 注册位置与接收入口说明
+- 收到 URI 后如何转交给播放器逻辑
+- 与 `aionowplaying` 的接口衔接方式
+
+### README 引用要求
+
+README 和 `README.zh-CN.md` 需要新增单独章节，明确说明：
+
+- `on_open_uri` 在 macOS / Windows 上的限制
+- “本地打开 URI”和“接收 URI 激活”是两件事
+- 宿主接入示例文档的入口链接
+
+README 不应承载全部平台细节，而应承担总览与跳转职责。
+
+### Sphinx 文档引用要求
+
+Sphinx 文档中需要把这些示例页纳入目录树，并至少从以下位置可达：
+
+- `docs/index.rst`
+- Quick Start 或单独的集成说明入口页
+
+目标是让 Read the Docs 用户可以从文档首页进入这些平台示例，而不是只能从仓库根 README 查找。
+
+## 平台设计
+
+### macOS
+
+#### 本地打开 URI
+
+宿主或接口层可调用：
+
+- `NSWorkspace.sharedWorkspace().openURL_(url)`
+
+这适合“主动打开 URI”。
+
+#### 接收 URI 激活
+
+宿主应用需要：
+
+- 以 `.app` bundle 形式运行
+- 在 `Info.plist` 中注册 `CFBundleURLTypes`
+- 在 AppKit 生命周期中接收外部 URL 激活事件
+
+收到 URI 后，宿主应用应将其转换为内部统一格式，例如：
+
+- 直接播放资源 URI
+- 或解析宿主自定义协议，例如 `myplayer://open?target=...`
+
+然后再进入自身播放逻辑。
+
+#### 对本项目的含义
+
+如果当前项目仅作为 Python 库存在，而没有自己的 `.app` 宿主，则“接收 URI 激活”无法由库单独完成。
+
+因此需要额外提供一个 macOS 宿主接入示例页面，说明：
+
+- `Info.plist` 中如何注册 URL scheme
+- AppKit 生命周期中如何接收 URL
+- 如何把收到的 URI 传回播放器逻辑
+
+### Windows
+
+#### 本地打开 URI
+
+宿主或接口层可调用：
+
+- 首选：`Windows.System.Launcher.LaunchUriAsync`
+- 桌面应用兼容方案：`ShellExecute`
+
+这适合“主动打开 URI”。
+
+#### 接收 URI 激活
+
+宿主应用需要：
+
+- 注册自定义协议
+- 打包应用可在 manifest 中声明协议
+- 未打包桌面应用通常通过安装阶段写入注册表实现协议关联
+
+当用户或外部程序打开该协议时：
+
+- 系统拉起宿主应用
+- 宿主应用从激活参数或命令行参数中拿到 URI
+- 再进入自身逻辑处理
+
+#### 对本项目的含义
+
+与 macOS 相同，库本身不能替代宿主完成协议注册，只能提供统一接口和调用契约。
+
+因此需要额外提供一个 Windows 宿主接入示例页面，说明：
+
+- 打包应用如何声明协议，或未打包桌面应用如何完成协议关联
+- 宿主应用如何获取激活参数或命令行参数
+- 如何把收到的 URI 传回播放器逻辑
+
+## 统一 URI 契约建议
+
+建议定义一个最小统一参数契约，而不是强制规定统一的外部 scheme。
+
+### 对外协议建议
+
+协议 scheme 不由 `aionowplaying` 强制规定，应由宿主应用自行决定。
+
+例如宿主可以采用：
+
+```text
+myplayer://open?target=<encoded-uri>
+```
+
+或者：
+
+```text
+examplemusic://play?target=<encoded-uri>
+```
+
+`aionowplaying` 只建议约定 URI 的参数结构和解析后如何交给播放器逻辑，不规定最终对外暴露的协议名。
+
+优点：
+
+- 不绑死宿主品牌或产品命名
+- 更符合库定位，而不是应用框架定位
+- 仍然可以约定统一的参数结构，例如 `target`、`playlist`、`position`、`source`
+
+### 宿主内部处理建议
+
+宿主接收到 URI 后分两步：
+
+1. 解析 scheme 和 action
+2. 提取 `target`
+
+随后根据业务需要二选一：
+
+- 交给系统默认应用处理
+- 在播放器内部自行加载
+
+## 对代码结构的建议
+
+### 库层最小能力
+
+建议保持现有 `BaseInterface.on_open_uri(uri)` 作为统一抽象入口。
+
+同时可考虑新增一个更明确的宿主协作层抽象，例如：
+
+- `handle_activated_uri(uri: str)`
+
+用途是区分：
+
+- `on_open_uri`：系统媒体层希望应用打开某个 URI
+- `handle_activated_uri`：宿主应用被外部协议唤起后，把 URI 交回应用逻辑
+
+这两个入口最终可以复用相同业务逻辑，但语义上建议区分，以免后续概念混乱。
+
+### 宿主接入契约
+
+建议在文档中明确宿主最少要实现：
+
+1. 注册协议
+2. 接收系统传入的 URI
+3. 调用统一解析函数
+4. 将解析结果交给播放器控制层
+
+## 测试策略建议
+
+由于 URI 激活涉及真实系统环境，CI 不应依赖桌面环境做端到端验证。
+
+建议测试拆成三层：
+
+### 1. 纯解析测试
+
+测试统一 URI 格式解析，例如：
+
+- 合法 scheme
+- 缺失 `target`
+- 非法 action
+- 编码后 URI 还原
+
+### 2. 平台 opener 测试
+
+通过 mock 验证：
+
+- macOS opener 正确调用 `NSWorkspace`
+- Windows opener 正确调用 `LaunchUriAsync` 或 `ShellExecute`
+
+### 3. 宿主适配示例测试
+
+如果后续提供示例宿主，则只测试：
+
+- 激活参数到内部处理函数的转发
+
+不在 CI 中要求真实注册协议并唤起桌面应用。
+
+### 4. 文档链接可达性检查
+
+需要增加基础文档检查，确保：
+
+- README 中引用的示例页面路径存在
+- Sphinx `toctree` 正确包含示例页
+- 本地构建文档时页面可访问
+
+## 风险与限制
+
+### 1. 库不能单独完成 URI 激活
+
+没有宿主应用时，库无法直接成为系统协议处理器。
+
+### 2. 平台注册流程不属于媒体接口本身
+
+这部分是应用分发和系统集成问题，不应强行塞进 `MPNowPlaying` 或 `SMTC` 抽象层。
+
+### 3. URI 安全性需要由宿主控制
+
+宿主需要决定：
+
+- 允许哪些 scheme
+- 是否允许远程内容
+- 是否限制本地文件访问
+
+这些策略不建议由底层媒体接口层默认决定。
+
+## 分阶段落地建议
+
+### 第一阶段
+
+先实现“本地打开 URI”：
+
+- macOS: `NSWorkspace`
+- Windows: `LaunchUriAsync` 或 `ShellExecute`
+
+目标是补齐 issue #17 的最小跨平台能力。
+
+### 第二阶段
+
+补充统一 URI 参数契约文档与解析工具。
+
+目标是让宿主应用有统一接入契约。
+
+### 第三阶段
+
+提供宿主接入示例与文档入口：
+
+- macOS URL scheme 示例
+- Windows protocol handler 示例
+- README / README.zh-CN 引用入口
+- Sphinx 独立页面与目录树入口
+
+目标是打通“外部唤起应用”的完整链路。
+
+## 最终建议
+
+对于当前仓库，最合理的方向不是尝试让 `MPNowPlaying` 或 `SMTC` 原生支持 `OpenUri`，因为官方能力边界并不支持这样设计。
+
+更合理的设计是：
+
+- 把 `OpenUri` 视为跨平台抽象能力
+- 在 macOS / Windows 上用本地系统 API 实现“主动打开 URI”
+- 把“接收 URI 激活”交给宿主应用去完成
+- 通过统一协议和回调契约把宿主与库连接起来
+
+这样既符合官方平台模型，也与 `aionowplaying` 当前作为跨平台库的定位保持一致。
+
+## 参考资料
+
+- Apple `MPNowPlayingInfoCenter`
+- Apple `MPRemoteCommandCenter`
+- Apple `NSWorkspace`
+- Apple custom URL scheme / `CFBundleURLTypes`
+- Microsoft `SystemMediaTransportControls`
+- Microsoft `Launcher.LaunchUriAsync`
+- Microsoft URI activation / protocol handler

--- a/src/aionowplaying/interface/macos.py
+++ b/src/aionowplaying/interface/macos.py
@@ -3,7 +3,7 @@ import os
 from typing import Any
 
 from Foundation import NSMutableDictionary, NSURL
-from AppKit import NSImage
+from AppKit import NSWorkspace, NSImage
 from MediaPlayer import MPRemoteCommandCenter, MPNowPlayingInfoCenter
 from MediaPlayer import (
     MPMediaItemPropertyTitle, MPMediaItemPropertyArtist, MPMediaItemPropertyAlbumTitle,
@@ -227,6 +227,15 @@ class MacOSInterface(BaseInterface):
 
     async def start(self):
         pass
+
+    async def on_open_uri(self, uri: str):
+        url = NSURL.URLWithString_(uri)
+        if url is None:
+            raise ValueError(f"Invalid URI: {uri}")
+
+        workspace = NSWorkspace.sharedWorkspace()
+        if not workspace.openURL_(url):
+            raise RuntimeError(f"Failed to open URI: {uri}")
 
     async def _handle_change_playback_position(self, event: MPChangePlaybackPositionCommandEvent):
         if not self.get_playback_property(PlaybackPropertyName.CanSeek):

--- a/src/aionowplaying/interface/windows.py
+++ b/src/aionowplaying/interface/windows.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import webbrowser
 import threading
 from typing import Any
 from datetime import timedelta
@@ -22,6 +23,14 @@ from aionowplaying.interface.base import TrackListPropertyName, PlaybackStatus, 
 
 def TimeSpan(x_microsec):
     return timedelta(microseconds=x_microsec)
+
+
+def _open_uri_with_system(uri: str):
+    if not uri:
+        raise ValueError("URI must not be empty")
+
+    if not webbrowser.open(uri):
+        raise RuntimeError(f"Failed to open URI: {uri}")
 
 
 class WindowsInterface(BaseInterface):
@@ -273,6 +282,9 @@ class WindowsInterface(BaseInterface):
     async def start(self):
         # Don't need a background server for Windows
         pass
+
+    async def on_open_uri(self, uri: str):
+        await asyncio.to_thread(_open_uri_with_system, uri)
 
     async def stop(self):
         self._running = False

--- a/tests/test_open_uri_helpers.py
+++ b/tests/test_open_uri_helpers.py
@@ -1,0 +1,352 @@
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def _install_fake_frameworks(monkeypatch, url_factory, open_result=True):
+    foundation = ModuleType("Foundation")
+    appkit = ModuleType("AppKit")
+    mediaplayer = ModuleType("MediaPlayer")
+
+    class _FakeNSMutableDictionary(dict):
+        @classmethod
+        def dictionary(cls):
+            return cls()
+
+        def mutableCopy(self):
+            return _FakeNSMutableDictionary(self)
+
+    class _FakeNSURL:
+        calls = []
+
+        @staticmethod
+        def URLWithString_(uri):
+            _FakeNSURL.calls.append(uri)
+            return url_factory(uri)
+
+    class _FakeNSImage:
+        @classmethod
+        def alloc(cls):
+            return cls()
+
+        def initWithContentsOfURL_(self, _):
+            return self
+
+        def size(self):
+            return (0, 0)
+
+    class _FakeWorkspace:
+        def __init__(self):
+            self.opened_urls = []
+
+        def openURL_(self, url):
+            self.opened_urls.append(url)
+            return open_result
+
+    class _FakeNSWorkspace:
+        workspace = _FakeWorkspace()
+
+        @classmethod
+        def sharedWorkspace(cls):
+            return cls.workspace
+
+    class _FakeCommand:
+        def addTargetWithHandler_(self, _):
+            return None
+
+    class _FakeCommandCenter:
+        @classmethod
+        def sharedCommandCenter(cls):
+            return cls()
+
+        def togglePlayPauseCommand(self):
+            return _FakeCommand()
+
+        def playCommand(self):
+            return _FakeCommand()
+
+        def pauseCommand(self):
+            return _FakeCommand()
+
+        def nextTrackCommand(self):
+            return _FakeCommand()
+
+        def previousTrackCommand(self):
+            return _FakeCommand()
+
+        def stopCommand(self):
+            return _FakeCommand()
+
+        def changePlaybackPositionCommand(self):
+            return _FakeCommand()
+
+        def changePlaybackRateCommand(self):
+            return _FakeCommand()
+
+        def changeRepeatModeCommand(self):
+            return _FakeCommand()
+
+        def changeShuffleModeCommand(self):
+            return _FakeCommand()
+
+    class _FakeNowPlayingInfoCenter:
+        @classmethod
+        def defaultCenter(cls):
+            return cls()
+
+        def nowPlayingInfo(self):
+            return None
+
+        def setNowPlayingInfo_(self, _):
+            return None
+
+        def setPlaybackState_(self, _):
+            return None
+
+    foundation.NSMutableDictionary = _FakeNSMutableDictionary
+    foundation.NSURL = _FakeNSURL
+    appkit.NSImage = _FakeNSImage
+    appkit.NSWorkspace = _FakeNSWorkspace
+    mediaplayer.MPRemoteCommandCenter = _FakeCommandCenter
+    mediaplayer.MPNowPlayingInfoCenter = _FakeNowPlayingInfoCenter
+    mediaplayer.MPMusicPlaybackStatePlaying = "playing"
+    mediaplayer.MPMusicPlaybackStatePaused = "paused"
+    mediaplayer.MPMusicPlaybackStateStopped = "stopped"
+    mediaplayer.MPMediaItemPropertyTitle = "title"
+    mediaplayer.MPMediaItemPropertyArtist = "artist"
+    mediaplayer.MPMediaItemPropertyAlbumTitle = "album"
+    mediaplayer.MPMediaItemPropertyPlaybackDuration = "duration"
+    mediaplayer.MPNowPlayingInfoPropertyPlaybackRate = "rate"
+    mediaplayer.MPNowPlayingInfoPropertyElapsedPlaybackTime = "elapsed"
+    mediaplayer.MPRemoteCommandHandlerStatusSuccess = 0
+    mediaplayer.MPNowPlayingInfoPropertyDefaultPlaybackRate = "default_rate"
+    mediaplayer.MPMediaItemPropertyAlbumArtist = "album_artist"
+    mediaplayer.MPMediaItemPropertyComposer = "composer"
+    mediaplayer.MPMediaItemPropertyGenre = "genre"
+    mediaplayer.MPMediaItemPropertyArtwork = "artwork"
+
+    monkeypatch.setitem(sys.modules, "Foundation", foundation)
+    monkeypatch.setitem(sys.modules, "AppKit", appkit)
+    monkeypatch.setitem(sys.modules, "MediaPlayer", mediaplayer)
+    sys.modules.pop("aionowplaying.interface.macos", None)
+
+    macos = importlib.import_module("aionowplaying.interface.macos")
+    return macos, _FakeNSURL, _FakeNSWorkspace.workspace
+
+
+def _install_fake_winrt(monkeypatch):
+    winrt = ModuleType("winrt")
+    system = ModuleType("winrt.system")
+    windows = ModuleType("winrt.windows")
+    foundation = ModuleType("winrt.windows.foundation")
+    media = ModuleType("winrt.windows.media")
+    playback = ModuleType("winrt.windows.media.playback")
+    storage = ModuleType("winrt.windows.storage")
+    streams = ModuleType("winrt.windows.storage.streams")
+
+    class _FakeArray(list):
+        pass
+
+    class _FakeUri:
+        def __init__(self, value):
+            self.value = value
+
+    class _FakeTimeline:
+        def __init__(self):
+            self.start_time = None
+            self.min_seek_time = None
+            self.max_seek_time = None
+            self.end_time = None
+            self.position = None
+
+    class _FakeDisplayUpdater:
+        def __init__(self):
+            self.type = None
+            self.app_media_id = None
+            self.music_properties = ModuleType("music_properties")
+            self.thumbnail = None
+
+        def update(self):
+            return None
+
+    class _FakeControls:
+        def __init__(self):
+            self.display_updater = _FakeDisplayUpdater()
+            self.sound_level = None
+            self.playback_status = None
+            self.playback_rate = None
+            self.shuffle_enabled = None
+            self.auto_repeat_mode = None
+            self.is_stop_enabled = None
+            self.is_play_enabled = None
+            self.is_pause_enabled = None
+            self.is_next_enabled = None
+            self.is_previous_enabled = None
+
+        def add_auto_repeat_mode_change_requested(self, _):
+            return None
+
+        def add_button_pressed(self, _):
+            return None
+
+        def add_playback_position_change_requested(self, _):
+            return None
+
+        def add_playback_rate_change_requested(self, _):
+            return None
+
+        def add_property_changed(self, _):
+            return None
+
+        def add_shuffle_enabled_change_requested(self, _):
+            return None
+
+        def update_timeline_properties(self, _):
+            return None
+
+    class _FakeCommandManager:
+        is_enabled = False
+
+    class _FakeMediaPlayer:
+        def __init__(self):
+            self.command_manager = _FakeCommandManager()
+            self.system_media_transport_controls = _FakeControls()
+
+    class _FakeRandomAccessStreamReference:
+        @classmethod
+        def create_from_uri(cls, _):
+            return cls()
+
+    class _FakeEnumValue:
+        def __init__(self, value):
+            self.value = value
+
+    class _FakeEnumNamespace:
+        MUSIC = _FakeEnumValue("music")
+        IMAGE = _FakeEnumValue("image")
+        VIDEO = _FakeEnumValue("video")
+        PLAYING = _FakeEnumValue("playing")
+        PAUSED = _FakeEnumValue("paused")
+        STOPPED = _FakeEnumValue("stopped")
+        NONE = _FakeEnumValue("none")
+        LIST = _FakeEnumValue("list")
+        TRACK = _FakeEnumValue("track")
+        SOUND_LEVEL = _FakeEnumValue("sound_level")
+        PLAY = _FakeEnumValue("play")
+        PAUSE = _FakeEnumValue("pause")
+        NEXT = _FakeEnumValue("next")
+        PREVIOUS = _FakeEnumValue("previous")
+        STOP = _FakeEnumValue("stop")
+
+    system.Array = _FakeArray
+    foundation.Uri = _FakeUri
+    media.SystemMediaTransportControlsTimelineProperties = _FakeTimeline
+    media.SystemMediaTransportControls = _FakeControls
+    media.SystemMediaTransportControlsDisplayUpdater = _FakeDisplayUpdater
+    media.MediaPlaybackStatus = _FakeEnumNamespace
+    media.MediaPlaybackType = _FakeEnumNamespace
+    media.MediaPlaybackAutoRepeatMode = _FakeEnumNamespace
+    media.AutoRepeatModeChangeRequestedEventArgs = object
+    media.SystemMediaTransportControlsButtonPressedEventArgs = object
+    media.SystemMediaTransportControlsButton = _FakeEnumNamespace
+    media.PlaybackPositionChangeRequestedEventArgs = object
+    media.PlaybackRateChangeRequestedEventArgs = object
+    media.SystemMediaTransportControlsPropertyChangedEventArgs = object
+    media.SystemMediaTransportControlsProperty = _FakeEnumNamespace
+    media.ShuffleEnabledChangeRequestedEventArgs = object
+    playback.MediaPlayer = _FakeMediaPlayer
+    streams.RandomAccessStreamReference = _FakeRandomAccessStreamReference
+
+    monkeypatch.setitem(sys.modules, "winrt", winrt)
+    monkeypatch.setitem(sys.modules, "winrt.system", system)
+    monkeypatch.setitem(sys.modules, "winrt.windows", windows)
+    monkeypatch.setitem(sys.modules, "winrt.windows.foundation", foundation)
+    monkeypatch.setitem(sys.modules, "winrt.windows.media", media)
+    monkeypatch.setitem(sys.modules, "winrt.windows.media.playback", playback)
+    monkeypatch.setitem(sys.modules, "winrt.windows.storage", storage)
+    monkeypatch.setitem(sys.modules, "winrt.windows.storage.streams", streams)
+    sys.modules.pop("aionowplaying.interface.windows", None)
+
+    return importlib.import_module("aionowplaying.interface.windows")
+
+
+def test_on_open_uri_opens_valid_uri(monkeypatch):
+    sentinel_url = object()
+    macos, fake_nsurl, workspace = _install_fake_frameworks(
+        monkeypatch,
+        url_factory=lambda uri: sentinel_url if uri == "https://example.com" else None,
+        open_result=True,
+    )
+
+    it = object.__new__(macos.MacOSInterface)
+    asyncio.run(macos.MacOSInterface.on_open_uri(it, "https://example.com"))
+
+    assert fake_nsurl.calls == ["https://example.com"]
+    assert workspace.opened_urls == [sentinel_url]
+
+
+def test_on_open_uri_rejects_invalid_uri(monkeypatch):
+    macos, fake_nsurl, workspace = _install_fake_frameworks(
+        monkeypatch,
+        url_factory=lambda _uri: None,
+        open_result=True,
+    )
+
+    it = object.__new__(macos.MacOSInterface)
+
+    with pytest.raises(ValueError):
+        asyncio.run(macos.MacOSInterface.on_open_uri(it, "not-a-uri"))
+
+    assert fake_nsurl.calls == ["not-a-uri"]
+    assert workspace.opened_urls == []
+
+
+def test_on_open_uri_raises_when_workspace_open_fails(monkeypatch):
+    sentinel_url = object()
+    macos, fake_nsurl, workspace = _install_fake_frameworks(
+        monkeypatch,
+        url_factory=lambda uri: sentinel_url if uri == "https://example.com" else None,
+        open_result=False,
+    )
+
+    it = object.__new__(macos.MacOSInterface)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(macos.MacOSInterface.on_open_uri(it, "https://example.com"))
+
+    assert fake_nsurl.calls == ["https://example.com"]
+    assert workspace.opened_urls == [sentinel_url]
+
+
+def test_windows_open_uri_helper_opens_valid_uri(monkeypatch):
+    windows = _install_fake_winrt(monkeypatch)
+    calls = []
+    monkeypatch.setattr(windows.webbrowser, "open", lambda uri: calls.append(uri) or True)
+
+    result = windows._open_uri_with_system("https://example.com")
+
+    assert result is None
+    assert calls == ["https://example.com"]
+
+
+def test_windows_open_uri_helper_rejects_empty_uri(monkeypatch):
+    windows = _install_fake_winrt(monkeypatch)
+
+    with pytest.raises(ValueError):
+        windows._open_uri_with_system("")
+
+
+def test_windows_open_uri_helper_raises_when_system_opener_fails(monkeypatch):
+    windows = _install_fake_winrt(monkeypatch)
+    monkeypatch.setattr(windows.webbrowser, "open", lambda uri: False)
+
+    with pytest.raises(RuntimeError):
+        windows._open_uri_with_system("https://example.com")


### PR DESCRIPTION
## Summary

- add local OpenUri helpers for macOS and Windows
- document the boundary between library-level URI opening and host-managed URI activation
- add macOS and Windows host integration example pages and link them from README/docs

## Why

Linux exposes `on_open_uri` natively through MPRIS, but macOS and Windows need library-level helpers for opening a URI from the current process plus host-side documentation for protocol registration and activation handling.

## Validation

- pytest -q tests/test_open_uri_helpers.py
- PYTHONPATH=src pytest -q tests/test_macos_interface.py tests/test_windows_interface.py
- sphinx-build -b html docs docs/_build/html

Closes #17 
