### PR TITLE
[codex] 补齐 Linux MPRIS TrackList 支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The tables below describe native backend coverage for each `BaseInterface` metho
 - `⚪ Cache only`: stored locally, but not exposed by the native platform API.
 - `🔴 Unimplemented`: no platform-specific implementation. Base no-op methods are treated as unimplemented.
 
-Linux MPRIS2 backend exposes TrackList properties, methods, and signals when the application supplies tracklist callbacks.
+Linux MPRIS2 backend exposes TrackList properties, methods, and signals. Applications provide queue behavior by overriding tracklist callbacks and updating TrackList properties.
 
 ### Construction And Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Linux MPRIS2 backend exposes TrackList properties, methods, and signals when the
 | --- | --- | --- | --- |
 | `set_property` | 🟢 Native<br>player properties | ⚪ Cache only<br>no player-level API | ⚪ Cache only<br>no player-level API |
 | `set_playback_property` | 🟢 Native<br>playback properties | 🟡 Partial<br>some fields unsupported | 🟡 Partial<br>some fields local only |
-| `set_tracklist_property` | 🟢 Native<br>TrackList properties + signals | ⚪ Cache only | ⚪ Cache only |
+| `set_tracklist_property` | 🟢 Native<br>TrackList properties<br>with D-Bus updates | ⚪ Cache only | ⚪ Cache only |
 | `get_property` | 🟢 Native<br>player properties | ⚪ Cache only<br>cached value | ⚪ Cache only<br>cached value |
 | `get_playback_property` | 🟢 Native<br>playback properties | 🟡 Partial<br>`Position`/`Rate` native, others cached | ⚪ Cache only<br>cached value |
 | `get_tracklist_property` | 🟢 Native<br>TrackList properties | ⚪ Cache only<br>cached value | ⚪ Cache only<br>cached value |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The tables below describe native backend coverage for each `BaseInterface` metho
 - `⚪ Cache only`: stored locally, but not exposed by the native platform API.
 - `🔴 Unimplemented`: no platform-specific implementation. Base no-op methods are treated as unimplemented.
 
+Linux MPRIS2 backend exposes TrackList properties, methods, and signals when the application supplies tracklist callbacks.
+
 ### Construction And Lifecycle
 
 | Method | Linux (MPRIS2) | macOS | Windows |
@@ -134,7 +136,7 @@ The tables below describe native backend coverage for each `BaseInterface` metho
 | --- | --- | --- | --- |
 | `set_property` | 🟢 Native<br>player properties | ⚪ Cache only<br>no player-level API | ⚪ Cache only<br>no player-level API |
 | `set_playback_property` | 🟢 Native<br>playback properties | 🟡 Partial<br>some fields unsupported | 🟡 Partial<br>some fields local only |
-| `set_tracklist_property` | 🟢 Native<br>writes MPRIS TrackList properties | ⚪ Cache only | ⚪ Cache only |
+| `set_tracklist_property` | 🟢 Native<br>TrackList properties + signals | ⚪ Cache only | ⚪ Cache only |
 | `get_property` | 🟢 Native<br>player properties | ⚪ Cache only<br>cached value | ⚪ Cache only<br>cached value |
 | `get_playback_property` | 🟢 Native<br>playback properties | 🟡 Partial<br>`Position`/`Rate` native, others cached | ⚪ Cache only<br>cached value |
 | `get_tracklist_property` | 🟢 Native<br>TrackList properties | ⚪ Cache only<br>cached value | ⚪ Cache only<br>cached value |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,7 +137,7 @@ class MyPlayer(BaseInterface):
 | --- | --- | --- | --- |
 | `set_property` | 🟢 原生实现<br>player 属性 | ⚪ 仅缓存<br>无 player 级 API | ⚪ 仅缓存<br>无 player 级 API |
 | `set_playback_property` | 🟢 原生实现<br>playback 属性 | 🟡 部分实现<br>部分字段不支持 | 🟡 部分实现<br>部分字段仅本地 |
-| `set_tracklist_property` | 🟢 原生实现<br>TrackList 属性 + 信号 | ⚪ 仅缓存 | ⚪ 仅缓存 |
+| `set_tracklist_property` | 🟢 原生实现<br>TrackList 属性<br>含 D-Bus 更新通知 | ⚪ 仅缓存 | ⚪ 仅缓存 |
 | `get_property` | 🟢 原生实现<br>player 属性 | ⚪ 仅缓存<br>缓存值 | ⚪ 仅缓存<br>缓存值 |
 | `get_playback_property` | 🟢 原生实现<br>playback 属性 | 🟡 部分实现<br>`Position`/`Rate` 原生，其余缓存 | ⚪ 仅缓存<br>缓存值 |
 | `get_tracklist_property` | 🟢 原生实现<br>TrackList 属性 | ⚪ 仅缓存<br>缓存值 | ⚪ 仅缓存<br>缓存值 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,6 +89,8 @@ class MyPlayer(BaseInterface):
 - `⚪ 仅缓存`：只保存在本地状态中，不会映射到系统原生 API。
 - `🔴 未实现`：没有平台特定实现。基类默认空实现统一视为未实现。
 
+当应用提供 tracklist 回调时，Linux MPRIS2 后端会暴露 TrackList 属性、方法和信号。
+
 ### 构造与生命周期
 
 | 方法 | Linux (MPRIS2) | macOS | Windows |
@@ -135,7 +137,7 @@ class MyPlayer(BaseInterface):
 | --- | --- | --- | --- |
 | `set_property` | 🟢 原生实现<br>player 属性 | ⚪ 仅缓存<br>无 player 级 API | ⚪ 仅缓存<br>无 player 级 API |
 | `set_playback_property` | 🟢 原生实现<br>playback 属性 | 🟡 部分实现<br>部分字段不支持 | 🟡 部分实现<br>部分字段仅本地 |
-| `set_tracklist_property` | 🟢 原生实现<br>写入 MPRIS TrackList 属性 | ⚪ 仅缓存 | ⚪ 仅缓存 |
+| `set_tracklist_property` | 🟢 原生实现<br>TrackList 属性 + 信号 | ⚪ 仅缓存 | ⚪ 仅缓存 |
 | `get_property` | 🟢 原生实现<br>player 属性 | ⚪ 仅缓存<br>缓存值 | ⚪ 仅缓存<br>缓存值 |
 | `get_playback_property` | 🟢 原生实现<br>playback 属性 | 🟡 部分实现<br>`Position`/`Rate` 原生，其余缓存 | ⚪ 仅缓存<br>缓存值 |
 | `get_tracklist_property` | 🟢 原生实现<br>TrackList 属性 | ⚪ 仅缓存<br>缓存值 | ⚪ 仅缓存<br>缓存值 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,7 @@ class MyPlayer(BaseInterface):
 - `⚪ 仅缓存`：只保存在本地状态中，不会映射到系统原生 API。
 - `🔴 未实现`：没有平台特定实现。基类默认空实现统一视为未实现。
 
-当应用提供 tracklist 回调时，Linux MPRIS2 后端会暴露 TrackList 属性、方法和信号。
+Linux MPRIS2 后端会暴露 TrackList 属性、方法和信号。应用通过覆写 tracklist 回调并更新 TrackList 属性来提供实际队列行为。
 
 ### 构造与生命周期
 

--- a/src/aionowplaying/interface/base.py
+++ b/src/aionowplaying/interface/base.py
@@ -237,6 +237,30 @@ class BaseInterface:
     async def on_set_position(self, track_id: str, position: int):
         pass
 
+    async def on_get_tracks_metadata(self, track_ids: list[str]) -> list[PlaybackProperties.MetadataBean]:
+        return []
+
+    async def on_add_track(self, uri: str, after_track: str, set_as_current: bool):
+        pass
+
+    async def on_remove_track(self, track_id: str):
+        pass
+
+    async def on_goto(self, track_id: str):
+        pass
+
+    async def track_added(self, metadata: PlaybackProperties.MetadataBean, after_track: str):
+        pass
+
+    async def track_removed(self, track_id: str):
+        pass
+
+    async def track_list_replaced(self, tracks: list[str], current_track: str):
+        pass
+
+    async def track_metadata_changed(self, track_id: str, metadata: PlaybackProperties.MetadataBean):
+        pass
+
     async def seeked(self, position: int):
         pass
 

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -262,6 +262,22 @@ class MprisTracklistServiceInterface(ServiceInterface):
     def tracks(self) -> 'ao':
         return self._properties.Tracks
 
+    @signal(name="TrackAdded")
+    async def track_added(self, metadata: dict, after_track: str) -> "a{sv}o":
+        return metadata, after_track
+
+    @signal(name="TrackRemoved")
+    async def track_removed(self, track_id: str) -> "o":
+        return track_id
+
+    @signal(name="TrackListReplaced")
+    async def track_list_replaced(self, tracks: list[str], current_track: str) -> "aoo":
+        return tracks, current_track
+
+    @signal(name="TrackMetadataChanged")
+    async def track_metadata_changed(self, track_id: str, metadata: dict) -> "oa{sv}":
+        return track_id, metadata
+
     @method(name="GetTracksMetadata")
     async def get_tracks_metadata(self, track_ids: 'ao') -> 'aa{sv}':
         items = await self._it.on_get_tracks_metadata(list(track_ids))
@@ -318,6 +334,18 @@ class Mpris2Interface(BaseInterface):
 
     async def seeked(self, position: int):
         await self._player_bus.seeked(position)
+
+    async def track_added(self, metadata, after_track):
+        await self._tracklist_bus.track_added(DBusBeanMapper.metadata(metadata), after_track)
+
+    async def track_removed(self, track_id):
+        await self._tracklist_bus.track_removed(track_id)
+
+    async def track_list_replaced(self, tracks, current_track):
+        await self._tracklist_bus.track_list_replaced(tracks, current_track)
+
+    async def track_metadata_changed(self, track_id, metadata):
+        await self._tracklist_bus.track_metadata_changed(track_id, DBusBeanMapper.metadata(metadata))
 
     async def start(self):
         self.dbus = await MessageBus().connect()

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -12,7 +12,7 @@ class DBusBeanMapper:
     @staticmethod
     def metadata(metadata: PlaybackProperties.MetadataBean) -> dict:
         metadata_map = dict()
-        metadata_map['mpris:trackid'] = Variant('s', metadata.id_)
+        metadata_map['mpris:trackid'] = Variant('o', metadata.id_)
         metadata_map['mpris:length'] = Variant('x', metadata.duration)
         metadata_map['mpris:artUrl'] = Variant('s', metadata.cover)
         metadata_map['xesam:album'] = Variant('s', metadata.album)
@@ -261,6 +261,25 @@ class MprisTracklistServiceInterface(ServiceInterface):
     @dbus_property(access=PropertyAccess.READ, name=TrackListPropertyName.Tracks.value)
     def tracks(self) -> 'ao':
         return self._properties.Tracks
+
+    @method(name="GetTracksMetadata")
+    async def get_tracks_metadata(self, track_ids: 'ao') -> 'aa{sv}':
+        items = await self._it.on_get_tracks_metadata(list(track_ids))
+        return [DBusBeanMapper.metadata(item) for item in items]
+
+    @method(name="AddTrack")
+    async def add_track(self, uri: 's', after_track: 'o', set_as_current: 'b'):
+        if self._properties.CanEditTracks:
+            await self._it.on_add_track(uri, after_track, set_as_current)
+
+    @method(name="RemoveTrack")
+    async def remove_track(self, track_id: 'o'):
+        if self._properties.CanEditTracks:
+            await self._it.on_remove_track(track_id)
+
+    @method(name="GoTo")
+    async def go_to(self, track_id: 'o'):
+        await self._it.on_goto(track_id)
 
     def get_property(self, key):
         return getattr(self._properties, key)

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any
 
 from dbus_fast import PropertyAccess, Variant
@@ -263,19 +264,19 @@ class MprisTracklistServiceInterface(ServiceInterface):
         return self._properties.Tracks
 
     @signal(name="TrackAdded")
-    async def track_added(self, metadata: dict, after_track: str) -> "a{sv}o":
+    def track_added(self, metadata: dict, after_track: str) -> "a{sv}o":
         return metadata, after_track
 
     @signal(name="TrackRemoved")
-    async def track_removed(self, track_id: str) -> "o":
+    def track_removed(self, track_id: str) -> "o":
         return track_id
 
     @signal(name="TrackListReplaced")
-    async def track_list_replaced(self, tracks: list[str], current_track: str) -> "aoo":
+    def track_list_replaced(self, tracks: list[str], current_track: str) -> "aoo":
         return tracks, current_track
 
     @signal(name="TrackMetadataChanged")
-    async def track_metadata_changed(self, track_id: str, metadata: dict) -> "oa{sv}":
+    def track_metadata_changed(self, track_id: str, metadata: dict) -> "oa{sv}":
         return track_id, metadata
 
     @method(name="GetTracksMetadata")
@@ -335,17 +336,26 @@ class Mpris2Interface(BaseInterface):
     async def seeked(self, position: int):
         await self._player_bus.seeked(position)
 
+    async def _maybe_await(self, value):
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
     async def track_added(self, metadata, after_track):
-        await self._tracklist_bus.track_added(DBusBeanMapper.metadata(metadata), after_track)
+        result = self._tracklist_bus.track_added(DBusBeanMapper.metadata(metadata), after_track)
+        return await self._maybe_await(result)
 
     async def track_removed(self, track_id):
-        await self._tracklist_bus.track_removed(track_id)
+        result = self._tracklist_bus.track_removed(track_id)
+        return await self._maybe_await(result)
 
     async def track_list_replaced(self, tracks, current_track):
-        await self._tracklist_bus.track_list_replaced(tracks, current_track)
+        result = self._tracklist_bus.track_list_replaced(tracks, current_track)
+        return await self._maybe_await(result)
 
     async def track_metadata_changed(self, track_id, metadata):
-        await self._tracklist_bus.track_metadata_changed(track_id, DBusBeanMapper.metadata(metadata))
+        result = self._tracklist_bus.track_metadata_changed(track_id, DBusBeanMapper.metadata(metadata))
+        return await self._maybe_await(result)
 
     async def start(self):
         self.dbus = await MessageBus().connect()

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -254,6 +254,10 @@ class MprisTracklistServiceInterface(ServiceInterface):
 
     def set_property(self, name: str, value: Any):
         setattr(self._properties, name, value)
+        if name == TrackListPropertyName.Tracks.value:
+            self.emit_properties_changed({}, [name])
+        else:
+            self.emit_properties_changed({name: value})
 
     @dbus_property(access=PropertyAccess.READ, name=TrackListPropertyName.CanEditTracks.value)
     def can_edit_tracks(self) -> 'b':
@@ -361,6 +365,7 @@ class Mpris2Interface(BaseInterface):
         self.dbus = await MessageBus().connect()
         self.dbus.export(self._object_path, self._bus)
         self.dbus.export(self._object_path, self._player_bus)
+        self.dbus.export(self._object_path, self._tracklist_bus)
         await self.dbus.request_name(self._bus_name)
         await self.dbus.wait_for_disconnect()
 

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -273,6 +273,8 @@ class MprisTracklistServiceInterface(ServiceInterface):
         self._it = it
 
     def set_property(self, name: str, value: Any):
+        if name == TrackListPropertyName.Tracks.value:
+            value = [DBusBeanMapper._track_id_path(track_id) for track_id in value]
         setattr(self._properties, name, value)
         if name == TrackListPropertyName.Tracks.value:
             self.emit_properties_changed({}, [name])
@@ -367,19 +369,28 @@ class Mpris2Interface(BaseInterface):
         return value
 
     async def track_added(self, metadata, after_track):
-        result = self._tracklist_bus.track_added(DBusBeanMapper.metadata(metadata), after_track)
+        result = self._tracklist_bus.track_added(
+            DBusBeanMapper.metadata(metadata),
+            DBusBeanMapper._track_id_path(after_track),
+        )
         return await self._maybe_await(result)
 
     async def track_removed(self, track_id):
-        result = self._tracklist_bus.track_removed(track_id)
+        result = self._tracklist_bus.track_removed(DBusBeanMapper._track_id_path(track_id))
         return await self._maybe_await(result)
 
     async def track_list_replaced(self, tracks, current_track):
-        result = self._tracklist_bus.track_list_replaced(tracks, current_track)
+        result = self._tracklist_bus.track_list_replaced(
+            [DBusBeanMapper._track_id_path(track_id) for track_id in tracks],
+            DBusBeanMapper._track_id_path(current_track),
+        )
         return await self._maybe_await(result)
 
     async def track_metadata_changed(self, track_id, metadata):
-        result = self._tracklist_bus.track_metadata_changed(track_id, DBusBeanMapper.metadata(metadata))
+        result = self._tracklist_bus.track_metadata_changed(
+            DBusBeanMapper._track_id_path(track_id),
+            DBusBeanMapper.metadata(metadata),
+        )
         return await self._maybe_await(result)
 
     async def start(self):

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from typing import Any
 
 from dbus_fast import PropertyAccess, Variant
@@ -10,10 +11,29 @@ from aionowplaying.interface.base import BaseInterface, PropertyName, PlayerProp
 
 
 class DBusBeanMapper:
+    NO_TRACK_PATH = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+    TRACK_LIST_PATH = "/org/mpris/MediaPlayer2/TrackList"
+    _OBJECT_PATH_RE = re.compile(r"^/(?:[A-Za-z0-9_]+(?:/[A-Za-z0-9_]+)*)?$")
+    _TRACK_ID_SEGMENT_RE = re.compile(r"[^A-Za-z0-9_]")
+
+    @staticmethod
+    def _track_id_path(track_id: str) -> str:
+        if not track_id:
+            return DBusBeanMapper.NO_TRACK_PATH
+        if track_id.startswith("/") and DBusBeanMapper._OBJECT_PATH_RE.fullmatch(track_id):
+            return track_id
+
+        safe = DBusBeanMapper._TRACK_ID_SEGMENT_RE.sub("_", track_id)
+        if not safe:
+            safe = "track"
+        if safe[0].isdigit():
+            safe = f"track_{safe}"
+        return f"{DBusBeanMapper.TRACK_LIST_PATH}/{safe}"
+
     @staticmethod
     def metadata(metadata: PlaybackProperties.MetadataBean) -> dict:
         metadata_map = dict()
-        metadata_map['mpris:trackid'] = Variant('o', metadata.id_)
+        metadata_map['mpris:trackid'] = Variant('o', DBusBeanMapper._track_id_path(metadata.id_))
         metadata_map['mpris:length'] = Variant('x', metadata.duration)
         metadata_map['mpris:artUrl'] = Variant('s', metadata.cover)
         metadata_map['xesam:album'] = Variant('s', metadata.album)
@@ -316,6 +336,7 @@ class Mpris2Interface(BaseInterface):
         self._player_tracklist_name = 'org.mpris.MediaPlayer2.TrackList'
         self._object_path = '/org/mpris/MediaPlayer2'
         self._bus = MprisServiceInterface(self._entry_name, it=self)
+        self._bus._properties.HasTrackList = True
         self._player_bus = MprisPlayerServiceInterface(self._player_entry_name, it=self)
         self._tracklist_bus = MprisTracklistServiceInterface(self._player_tracklist_name, it=self)
 

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -42,6 +42,22 @@ def test_base_property_storage_roundtrip():
 
 
 @pytest.mark.asyncio
+async def test_base_tracklist_methods_default_values():
+    it = BaseInterface("base")
+
+    result = await it.on_get_tracks_metadata(["/track/1"])
+
+    assert result == []
+    await it.on_add_track("file:///song.mp3", "/org/mpris/MediaPlayer2/TrackList/NoTrack", False)
+    await it.on_remove_track("/track/1")
+    await it.on_goto("/track/1")
+    await it.track_added(PlaybackProperties.MetadataBean(id_="/track/1"), "/org/mpris/MediaPlayer2/TrackList/NoTrack")
+    await it.track_removed("/track/1")
+    await it.track_list_replaced(["/track/1"], "/track/1")
+    await it.track_metadata_changed("/track/1", PlaybackProperties.MetadataBean(id_="/track/1"))
+
+
+@pytest.mark.asyncio
 async def test_on_play_pause_calls_pause_when_playing():
     it = DummyInterface(PlaybackStatus.Playing)
     await it.on_play_pause()

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -337,6 +337,49 @@ def test_tracklist_dbus_properties():
 
 
 @pytest.mark.asyncio
+async def test_tracklist_methods_dispatch_to_interface():
+    calls = {
+        "metadata": None,
+        "add": None,
+        "remove": None,
+        "goto": None,
+    }
+
+    class It:
+        async def on_get_tracks_metadata(self, track_ids):
+            calls["metadata"] = track_ids
+            return [PlaybackProperties.MetadataBean(id_="/track/1", title="Song")]
+
+        async def on_add_track(self, uri, after_track, set_as_current):
+            calls["add"] = (uri, after_track, set_as_current)
+
+        async def on_remove_track(self, track_id):
+            calls["remove"] = track_id
+
+        async def on_goto(self, track_id):
+            calls["goto"] = track_id
+
+    tracklist = mpris2.MprisTracklistServiceInterface("org.mpris.MediaPlayer2.TrackList", it=It())
+    tracklist._properties.CanEditTracks = True
+
+    metadata = await type(tracklist).get_tracks_metadata.__wrapped__(tracklist, ["/track/1"])
+    await type(tracklist).add_track.__wrapped__(
+        tracklist,
+        "file:///song.mp3",
+        "/org/mpris/MediaPlayer2/TrackList/NoTrack",
+        True,
+    )
+    await type(tracklist).remove_track.__wrapped__(tracklist, "/track/1")
+    await type(tracklist).go_to.__wrapped__(tracklist, "/track/1")
+
+    assert calls["metadata"] == ["/track/1"]
+    assert calls["add"] == ("file:///song.mp3", "/org/mpris/MediaPlayer2/TrackList/NoTrack", True)
+    assert calls["remove"] == "/track/1"
+    assert calls["goto"] == "/track/1"
+    assert metadata[0]["mpris:trackid"].signature == "o"
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_setter_when_can_set_fullscreen_false():
     """Test that fullscreen setter does nothing when CanSetFullscreen is False."""
     called = {"fullscreen": 0}

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -189,9 +189,15 @@ async def test_mpris2_tracklist_signal_bridge():
     await it.track_metadata_changed("/track/1", metadata)
 
     assert emitted[0][0] == "added"
+    assert emitted[0][1]["mpris:trackid"].signature == "o"
+    assert emitted[0][1]["xesam:title"].value == "Song"
+    assert emitted[0][2] == "/org/mpris/MediaPlayer2/TrackList/NoTrack"
     assert emitted[1] == ("removed", "/track/1")
     assert emitted[2] == ("replaced", ["/track/1"], "/track/1")
     assert emitted[3][0] == "changed"
+    assert emitted[3][1] == "/track/1"
+    assert emitted[3][2]["mpris:trackid"].signature == "o"
+    assert emitted[3][2]["xesam:title"].value == "Song"
 
 
 def _get_dbus_prop(obj, name):

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -140,10 +140,14 @@ async def test_service_interface_raise_and_quit():
 @pytest.mark.asyncio
 async def test_tracklist_properties():
     tracklist = mpris2.MprisTracklistServiceInterface("org.mpris.MediaPlayer2.TrackList")
-    tracklist.set_property("Tracks", ["t1", "t2"])
+    tracklist.set_property("Tracks", ["a", "track-123", "/track/1"])
     tracklist.set_property("CanEditTracks", True)
 
-    assert tracklist.get_property("Tracks") == ["t1", "t2"]
+    assert tracklist.get_property("Tracks") == [
+        "/org/mpris/MediaPlayer2/TrackList/a",
+        "/org/mpris/MediaPlayer2/TrackList/track_123",
+        "/track/1",
+    ]
     assert tracklist.get_property("CanEditTracks") is True
 
 
@@ -195,7 +199,10 @@ async def test_mpris2_interface_start_stop_and_getters():
 
     assert it.get_property(PropertyName.CanQuit) is True
     assert it.get_playback_property(PlaybackPropertyName.PlaybackStatus) == PlaybackStatus.Playing
-    assert it.get_tracklist_property(TrackListPropertyName.Tracks) == ["a", "b"]
+    assert it.get_tracklist_property(TrackListPropertyName.Tracks) == [
+        "/org/mpris/MediaPlayer2/TrackList/a",
+        "/org/mpris/MediaPlayer2/TrackList/b",
+    ]
 
     await it.start()
     assert it.dbus is not None
@@ -234,19 +241,23 @@ async def test_mpris2_tracklist_signal_bridge():
     it._tracklist_bus.track_metadata_changed = fake_track_metadata_changed
 
     metadata = PlaybackProperties.MetadataBean(id_="/track/1", title="Song")
-    await it.track_added(metadata, "/org/mpris/MediaPlayer2/TrackList/NoTrack")
-    await it.track_removed("/track/1")
-    await it.track_list_replaced(["/track/1"], "/track/1")
-    await it.track_metadata_changed("/track/1", metadata)
+    await it.track_added(metadata, "after-1")
+    await it.track_removed("track-123")
+    await it.track_list_replaced(["a", "/track/1"], "current-1")
+    await it.track_metadata_changed("track-123", metadata)
 
     assert emitted[0][0] == "added"
     assert emitted[0][1]["mpris:trackid"].signature == "o"
     assert emitted[0][1]["xesam:title"].value == "Song"
-    assert emitted[0][2] == "/org/mpris/MediaPlayer2/TrackList/NoTrack"
-    assert emitted[1] == ("removed", "/track/1")
-    assert emitted[2] == ("replaced", ["/track/1"], "/track/1")
+    assert emitted[0][2] == "/org/mpris/MediaPlayer2/TrackList/after_1"
+    assert emitted[1] == ("removed", "/org/mpris/MediaPlayer2/TrackList/track_123")
+    assert emitted[2] == (
+        "replaced",
+        ["/org/mpris/MediaPlayer2/TrackList/a", "/track/1"],
+        "/org/mpris/MediaPlayer2/TrackList/current_1",
+    )
     assert emitted[3][0] == "changed"
-    assert emitted[3][1] == "/track/1"
+    assert emitted[3][1] == "/org/mpris/MediaPlayer2/TrackList/track_123"
     assert emitted[3][2]["mpris:trackid"].signature == "o"
     assert emitted[3][2]["xesam:title"].value == "Song"
 

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -380,6 +380,33 @@ async def test_tracklist_methods_dispatch_to_interface():
 
 
 @pytest.mark.asyncio
+async def test_tracklist_edit_methods_respect_can_edit_tracks():
+    calls = {
+        "add": 0,
+        "remove": 0,
+    }
+
+    class It:
+        async def on_add_track(self, uri, after_track, set_as_current):
+            calls["add"] += 1
+
+        async def on_remove_track(self, track_id):
+            calls["remove"] += 1
+
+    tracklist = mpris2.MprisTracklistServiceInterface("org.mpris.MediaPlayer2.TrackList", it=It())
+
+    await type(tracklist).add_track.__wrapped__(
+        tracklist,
+        "file:///song.mp3",
+        "/org/mpris/MediaPlayer2/TrackList/NoTrack",
+        True,
+    )
+    await type(tracklist).remove_track.__wrapped__(tracklist, "/track/1")
+
+    assert calls == {"add": 0, "remove": 0}
+
+
+@pytest.mark.asyncio
 async def test_fullscreen_setter_when_can_set_fullscreen_false():
     """Test that fullscreen setter does nothing when CanSetFullscreen is False."""
     called = {"fullscreen": 0}

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -160,6 +160,40 @@ async def test_mpris2_interface_start_stop_and_getters():
     monkeypatch.undo()
 
 
+@pytest.mark.asyncio
+async def test_mpris2_tracklist_signal_bridge():
+    it = mpris2.Mpris2Interface("player")
+    emitted = []
+
+    async def fake_track_added(metadata, after_track):
+        emitted.append(("added", metadata, after_track))
+
+    async def fake_track_removed(track_id):
+        emitted.append(("removed", track_id))
+
+    async def fake_track_list_replaced(tracks, current_track):
+        emitted.append(("replaced", tracks, current_track))
+
+    async def fake_track_metadata_changed(track_id, metadata):
+        emitted.append(("changed", track_id, metadata))
+
+    it._tracklist_bus.track_added = fake_track_added
+    it._tracklist_bus.track_removed = fake_track_removed
+    it._tracklist_bus.track_list_replaced = fake_track_list_replaced
+    it._tracklist_bus.track_metadata_changed = fake_track_metadata_changed
+
+    metadata = PlaybackProperties.MetadataBean(id_="/track/1", title="Song")
+    await it.track_added(metadata, "/org/mpris/MediaPlayer2/TrackList/NoTrack")
+    await it.track_removed("/track/1")
+    await it.track_list_replaced(["/track/1"], "/track/1")
+    await it.track_metadata_changed("/track/1", metadata)
+
+    assert emitted[0][0] == "added"
+    assert emitted[1] == ("removed", "/track/1")
+    assert emitted[2] == ("replaced", ["/track/1"], "/track/1")
+    assert emitted[3][0] == "changed"
+
+
 def _get_dbus_prop(obj, name):
     prop = getattr(type(obj), name)
     if not hasattr(prop, "fget"):

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -55,6 +55,21 @@ async def test_dbus_mapper_and_player_set_property():
     assert player.get_property(PlaybackPropertyName.Metadata.value) == meta
 
 
+def test_dbus_mapper_track_id_is_valid_object_path():
+    no_track = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+
+    mapped_default = mpris2.DBusBeanMapper.metadata(PlaybackProperties.MetadataBean())
+    assert mapped_default["mpris:trackid"].signature == "o"
+    assert mapped_default["mpris:trackid"].value == no_track
+
+    mapped_path = mpris2.DBusBeanMapper.metadata(PlaybackProperties.MetadataBean(id_="/track/1"))
+    assert mapped_path["mpris:trackid"].value == "/track/1"
+
+    mapped_text = mpris2.DBusBeanMapper.metadata(PlaybackProperties.MetadataBean(id_="track-123"))
+    assert mapped_text["mpris:trackid"].value.startswith("/org/mpris/MediaPlayer2/TrackList/")
+    assert "-" not in mapped_text["mpris:trackid"].value
+
+
 @pytest.mark.asyncio
 async def test_loop_status_respects_can_control():
     called = {"count": 0}
@@ -156,12 +171,15 @@ async def test_mpris2_start_exports_tracklist_bus():
     monkeypatch.setattr(mpris2, "MessageBus", _FakeBus)
     it = mpris2.Mpris2Interface("player")
 
+    assert it.get_property(PropertyName.HasTrackList) is True
+
     await it.start()
 
     exported_paths = [entry[0] for entry in it.dbus.exported]
     exported_ifaces = [entry[1] for entry in it.dbus.exported]
     assert exported_paths.count("/org/mpris/MediaPlayer2") == 3
     assert any(isinstance(iface, mpris2.MprisTracklistServiceInterface) for iface in exported_ifaces)
+    assert it.get_property(PropertyName.HasTrackList) is True
     monkeypatch.undo()
 
 

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -132,6 +132,39 @@ async def test_tracklist_properties():
     assert tracklist.get_property("CanEditTracks") is True
 
 
+def test_tracklist_set_property_emits_properties_changed(monkeypatch):
+    tracklist = mpris2.MprisTracklistServiceInterface("org.mpris.MediaPlayer2.TrackList")
+    emitted = []
+
+    def capture(*args):
+        emitted.append(args)
+
+    monkeypatch.setattr(tracklist, "emit_properties_changed", capture)
+
+    tracklist.set_property(TrackListPropertyName.CanEditTracks.value, True)
+    tracklist.set_property(TrackListPropertyName.Tracks.value, ["t1", "t2"])
+
+    assert emitted == [
+        ({TrackListPropertyName.CanEditTracks.value: True},),
+        ({}, [TrackListPropertyName.Tracks.value]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mpris2_start_exports_tracklist_bus():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(mpris2, "MessageBus", _FakeBus)
+    it = mpris2.Mpris2Interface("player")
+
+    await it.start()
+
+    exported_paths = [entry[0] for entry in it.dbus.exported]
+    exported_ifaces = [entry[1] for entry in it.dbus.exported]
+    assert exported_paths.count("/org/mpris/MediaPlayer2") == 3
+    assert any(isinstance(iface, mpris2.MprisTracklistServiceInterface) for iface in exported_ifaces)
+    monkeypatch.undo()
+
+
 @pytest.mark.asyncio
 async def test_mpris2_interface_start_stop_and_getters():
     monkeypatch = pytest.MonkeyPatch()

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -200,6 +200,24 @@ async def test_mpris2_tracklist_signal_bridge():
     assert emitted[3][2]["xesam:title"].value == "Song"
 
 
+def test_tracklist_signals_can_be_called_directly():
+    it = mpris2.Mpris2Interface("player")
+    no_track = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+    metadata = PlaybackProperties.MetadataBean(id_="/track/1", title="Song")
+    mapped = mpris2.DBusBeanMapper.metadata(metadata)
+
+    assert it._tracklist_bus.track_added(mapped, no_track) == (mapped, no_track)
+    assert it._tracklist_bus.track_removed("/track/1") == "/track/1"
+    assert it._tracklist_bus.track_list_replaced(["/track/1"], "/track/1") == (
+        ["/track/1"],
+        "/track/1",
+    )
+    assert it._tracklist_bus.track_metadata_changed("/track/1", mapped) == (
+        "/track/1",
+        mapped,
+    )
+
+
 def _get_dbus_prop(obj, name):
     prop = getattr(type(obj), name)
     if not hasattr(prop, "fget"):


### PR DESCRIPTION
## 变更内容

- 为 `BaseInterface` 增加 TrackList 回调与主动通知默认实现。
- 为 Linux MPRIS2 TrackList 补齐 methods、signals、D-Bus 导出和属性通知。
- 将 TrackList 相关 object path 输出规范化，确保 `mpris:trackid`、`Tracks`、TrackList signals 使用合法 D-Bus object path。
- 更新 README / README.zh-CN 的 Linux TrackList 能力说明。

## 影响

Linux MPRIS2 后端现在暴露完整 TrackList properties、methods 和 signals。应用可以通过覆写 TrackList 回调与更新 TrackList 属性提供队列行为；macOS / Windows 仍保持 cache-only 行为。

## 验证

- `uv run pytest tests/test_base_interface.py tests/test_mpris2_interface.py -v`：22 passed
- `uv run pytest -v`：59 passed, 39 skipped, 4 warnings

## 备注

最终 review 仅剩非阻塞 minor：普通 track id 的净化是 lossy 的，未来如需保证任意业务 id 唯一，可改为可逆编码或追加短 hash。