### PR TITLE
feat: expose all BaseInterface capabilities in NowPlaying

### DIFF
--- a/src/aionowplaying/__init__.py
+++ b/src/aionowplaying/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['NowPlaying', 'select_interface', 'BaseInterface', 'PropertyName', 'LoopStatus',
-           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus']
+           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus', 'MediaType']
 
 import warnings
 from typing import Type
@@ -7,7 +7,7 @@ from typing import Type
 from aionowplaying.nowplaying import NowPlaying
 from aionowplaying.interface import select_interface, BaseInterface
 from aionowplaying.interface.base import PropertyName, LoopStatus, PlaybackPropertyName, PlaybackProperties, \
-    PlaybackStatus
+    PlaybackStatus, MediaType
 
 
 def __getattr__(name: str):

--- a/src/aionowplaying/nowplaying.py
+++ b/src/aionowplaying/nowplaying.py
@@ -6,6 +6,7 @@ from aionowplaying.interface import _select_interface_impl
 from aionowplaying.interface.base import (
     BaseInterface,
     LoopStatus,
+    MediaType,
     PlaybackProperties,
     PlaybackPropertyName,
     PlaybackStatus,
@@ -38,6 +39,11 @@ class NowPlaying:
         on_volume: Callable[[float], Any] | None = None,
         on_shuffle: Callable[[bool], Any] | None = None,
         on_loop: Callable[[LoopStatus], Any] | None = None,
+        on_rate: Callable[[float], Any] | None = None,
+        on_play_pause: Callable[[], Any] | None = None,
+        on_quit: Callable[[], Any] | None = None,
+        on_raise: Callable[[], Any] | None = None,
+        on_fullscreen: Callable[[bool], Any] | None = None,
     ):
         self.name = name
         self._identity = identity or name
@@ -55,6 +61,11 @@ class NowPlaying:
             'on_volume': on_volume,
             'on_shuffle': on_shuffle,
             'on_loop': on_loop,
+            'on_rate': on_rate,
+            'on_play_pause': on_play_pause,
+            'on_quit': on_quit,
+            'on_raise': on_raise,
+            'on_fullscreen': on_fullscreen,
         }
 
         # Setup capabilities based on callbacks
@@ -71,7 +82,8 @@ class NowPlaying:
         """Setup playback capabilities based on provided callbacks."""
         control_callbacks = [
             'on_play', 'on_pause', 'on_next', 'on_previous',
-            'on_seek', 'on_stop', 'on_volume', 'on_shuffle', 'on_loop'
+            'on_seek', 'on_stop', 'on_volume', 'on_shuffle', 'on_loop',
+            'on_rate', 'on_play_pause',
         ]
 
         # Set CanControl if any control callback is registered
@@ -79,7 +91,7 @@ class NowPlaying:
         if has_control:
             self._interface.set_playback_property(PlaybackPropertyName.CanControl, True)
 
-        # Set specific capabilities
+        # Set specific playback capabilities
         callback_capability_map = {
             'on_play': PlaybackPropertyName.CanPlay,
             'on_pause': PlaybackPropertyName.CanPause,
@@ -91,6 +103,19 @@ class NowPlaying:
         for callback_name, capability in callback_capability_map.items():
             if self._callbacks.get(callback_name):
                 self._interface.set_playback_property(capability, True)
+
+        # on_play_pause implies both CanPlay and CanPause
+        if self._callbacks.get('on_play_pause'):
+            self._interface.set_playback_property(PlaybackPropertyName.CanPlay, True)
+            self._interface.set_playback_property(PlaybackPropertyName.CanPause, True)
+
+        # Set player-level capabilities
+        if self._callbacks.get('on_quit'):
+            self._interface.set_property(PropertyName.CanQuit, True)
+        if self._callbacks.get('on_raise'):
+            self._interface.set_property(PropertyName.CanRaise, True)
+        if self._callbacks.get('on_fullscreen'):
+            self._interface.set_property(PropertyName.CanSetFullscreen, True)
 
     def _run_callback(self, name: str, *args) -> None:
         """Execute a callback, handling both sync and async."""
@@ -130,6 +155,21 @@ class NowPlaying:
         async def wrapped_on_loop(status):
             self._run_callback('on_loop', status)
 
+        async def wrapped_on_rate(rate: float):
+            self._run_callback('on_rate', rate)
+
+        async def wrapped_on_play_pause():
+            self._run_callback('on_play_pause')
+
+        async def wrapped_on_quit():
+            self._run_callback('on_quit')
+
+        async def wrapped_on_raise():
+            self._run_callback('on_raise')
+
+        async def wrapped_on_fullscreen(fullscreen: bool):
+            self._run_callback('on_fullscreen', fullscreen)
+
         # Assign wrapped callbacks
         self._interface.on_play = wrapped_on_play
         self._interface.on_pause = wrapped_on_pause
@@ -140,6 +180,11 @@ class NowPlaying:
         self._interface.on_volume = wrapped_on_volume
         self._interface.on_shuffle = wrapped_on_shuffle
         self._interface.on_loop_status = wrapped_on_loop
+        self._interface.on_rate = wrapped_on_rate
+        self._interface.on_play_pause = wrapped_on_play_pause
+        self._interface.on_quit = wrapped_on_quit
+        self._interface.on_raise = wrapped_on_raise
+        self._interface.on_fullscreen = wrapped_on_fullscreen
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
         """Apply metadata to the playback properties."""
@@ -253,6 +298,70 @@ class NowPlaying:
         self._interface._playback_properties.Metadata.trackNumber = value
 
     @property
+    def id(self) -> str:
+        return self._interface._playback_properties.Metadata.id_
+
+    @id.setter
+    def id(self, value: str):
+        self._interface._playback_properties.Metadata.id_ = value
+
+    @property
+    def media_type(self) -> MediaType:
+        return self._interface._playback_properties.Metadata.media_type
+
+    @media_type.setter
+    def media_type(self, value: MediaType):
+        self._interface._playback_properties.Metadata.media_type = value
+
+    @property
+    def lyrics(self) -> str:
+        return self._interface._playback_properties.Metadata.lyrics
+
+    @lyrics.setter
+    def lyrics(self, value: str):
+        self._interface._playback_properties.Metadata.lyrics = value
+
+    @property
+    def comments(self) -> list[str]:
+        return self._interface._playback_properties.Metadata.comments
+
+    @comments.setter
+    def comments(self, value: list[str] | str):
+        if isinstance(value, str):
+            value = [value]
+        self._interface._playback_properties.Metadata.comments = value
+
+    @property
+    def composer(self) -> list[str]:
+        return self._interface._playback_properties.Metadata.composer
+
+    @composer.setter
+    def composer(self, value: list[str] | str):
+        if isinstance(value, str):
+            value = [value]
+        self._interface._playback_properties.Metadata.composer = value
+
+    @property
+    def genre(self) -> list[str]:
+        return self._interface._playback_properties.Metadata.genre
+
+    @genre.setter
+    def genre(self, value: list[str] | str):
+        if isinstance(value, str):
+            value = [value]
+        self._interface._playback_properties.Metadata.genre = value
+
+    @property
+    def lyricist(self) -> list[str]:
+        return self._interface._playback_properties.Metadata.lyricist
+
+    @lyricist.setter
+    def lyricist(self, value: list[str] | str):
+        if isinstance(value, str):
+            value = [value]
+        self._interface._playback_properties.Metadata.lyricist = value
+
+    @property
     def duration(self) -> timedelta | None:
         us = self._interface._playback_properties.Metadata.duration
         if us == 0:
@@ -349,6 +458,115 @@ class NowPlaying:
     def set_stopped(self) -> None:
         """Set playback status to Stopped."""
         self._interface.set_playback_property(PlaybackPropertyName.PlaybackStatus, PlaybackStatus.Stopped)
+
+    # Player-level properties
+
+    @property
+    def identity(self) -> str:
+        """Get player identity."""
+        return self._interface.get_property(PropertyName.Identity)
+
+    @identity.setter
+    def identity(self, value: str):
+        """Set player identity."""
+        self._interface.set_property(PropertyName.Identity, value)
+
+    @property
+    def desktop_entry(self) -> str:
+        """Get desktop entry name."""
+        return self._interface.get_property(PropertyName.DesktopEntry)
+
+    @desktop_entry.setter
+    def desktop_entry(self, value: str):
+        """Set desktop entry name."""
+        self._interface.set_property(PropertyName.DesktopEntry, value)
+
+    @property
+    def supported_uri_schemes(self) -> list[str]:
+        """Get supported URI schemes."""
+        return self._interface.get_property(PropertyName.SupportedUriSchemes)
+
+    @supported_uri_schemes.setter
+    def supported_uri_schemes(self, value: list[str]):
+        """Set supported URI schemes."""
+        self._interface.set_property(PropertyName.SupportedUriSchemes, value)
+
+    @property
+    def supported_mime_types(self) -> list[str]:
+        """Get supported MIME types."""
+        return self._interface.get_property(PropertyName.SupportedMimeTypes)
+
+    @supported_mime_types.setter
+    def supported_mime_types(self, value: list[str]):
+        """Set supported MIME types."""
+        self._interface.set_property(PropertyName.SupportedMimeTypes, value)
+
+    @property
+    def has_track_list(self) -> bool:
+        """Get whether player has a track list."""
+        return self._interface.get_property(PropertyName.HasTrackList)
+
+    @has_track_list.setter
+    def has_track_list(self, value: bool):
+        """Set whether player has a track list."""
+        self._interface.set_property(PropertyName.HasTrackList, value)
+
+    @property
+    def can_quit(self) -> bool:
+        """Get whether player supports quit."""
+        return self._interface.get_property(PropertyName.CanQuit)
+
+    @property
+    def can_raise(self) -> bool:
+        """Get whether player supports raise."""
+        return self._interface.get_property(PropertyName.CanRaise)
+
+    @property
+    def can_set_fullscreen(self) -> bool:
+        """Get whether player supports fullscreen toggle."""
+        return self._interface.get_property(PropertyName.CanSetFullscreen)
+
+    @property
+    def fullscreen(self) -> bool:
+        """Get whether player is fullscreen."""
+        return self._interface.get_property(PropertyName.Fullscreen)
+
+    @fullscreen.setter
+    def fullscreen(self, value: bool):
+        """Set fullscreen state."""
+        self._interface.set_property(PropertyName.Fullscreen, value)
+
+    # Seek notification
+
+    async def seeked(self, position: timedelta) -> None:
+        """Notify that a seek has occurred.
+
+        :param position: New playback position.
+        :type position: timedelta
+        """
+        await self._interface.seeked(self._timedelta_to_microseconds(position))
+
+    # Property access
+
+    def set_property(self, name: PropertyName, value: Any) -> None:
+        """Set a player-level property.
+
+        :param name: Property name.
+        :type name: PropertyName
+        :param value: Property value.
+        :type value: Any
+        """
+        self._interface.set_property(name, value)
+
+    def get_property(self, name: PropertyName) -> Any:
+        """Get a player-level property.
+
+        :param name: Property name.
+        :type name: PropertyName
+        :return: Property value.
+        :rtype: Any
+        """
+        return self._interface.get_property(name)
 
     # Lifecycle methods
 

--- a/tests/test_nowplaying.py
+++ b/tests/test_nowplaying.py
@@ -1,7 +1,7 @@
 import pytest
 
 import aionowplaying as aionp
-from aionowplaying import NowPlaying, PlaybackPropertyName, PlaybackStatus, LoopStatus
+from aionowplaying import NowPlaying, PlaybackPropertyName, PlaybackStatus, LoopStatus, PropertyName
 from aionowplaying.interface.base import MediaType
 from datetime import timedelta
 import asyncio
@@ -428,3 +428,279 @@ def test_nowplaying_interface_deprecation():
 
         assert len(w) >= 1
         assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+
+# New metadata properties tests
+
+def test_id_property():
+    """Test id property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.id = "track-123"
+    assert player.id == "track-123"
+
+
+def test_media_type_property():
+    """Test media_type property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.media_type = MediaType.Video
+    assert player.media_type == MediaType.Video
+
+
+def test_lyrics_property():
+    """Test lyrics property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.lyrics = "Some lyrics here"
+    assert player.lyrics == "Some lyrics here"
+
+
+def test_comments_property():
+    """Test comments property getter/setter."""
+    player = NowPlaying("Test Player")
+
+    # Test with list
+    player.comments = ["comment 1", "comment 2"]
+    assert player.comments == ["comment 1", "comment 2"]
+
+    # Test with string (should convert to list)
+    player.comments = "single comment"
+    assert player.comments == ["single comment"]
+
+
+def test_composer_property():
+    """Test composer property getter/setter."""
+    player = NowPlaying("Test Player")
+
+    player.composer = ["Composer 1", "Composer 2"]
+    assert player.composer == ["Composer 1", "Composer 2"]
+
+    player.composer = "Single Composer"
+    assert player.composer == ["Single Composer"]
+
+
+def test_genre_property():
+    """Test genre property getter/setter."""
+    player = NowPlaying("Test Player")
+
+    player.genre = ["Rock", "Pop"]
+    assert player.genre == ["Rock", "Pop"]
+
+    player.genre = "Jazz"
+    assert player.genre == ["Jazz"]
+
+
+def test_lyricist_property():
+    """Test lyricist property getter/setter."""
+    player = NowPlaying("Test Player")
+
+    player.lyricist = ["Lyricist 1"]
+    assert player.lyricist == ["Lyricist 1"]
+
+    player.lyricist = "Single Lyricist"
+    assert player.lyricist == ["Single Lyricist"]
+
+
+# New callback tests
+
+def test_capability_inference_from_new_callbacks():
+    """Test that capabilities are auto-inferred from new callbacks."""
+    player = NowPlaying(
+        "Test Player",
+        on_quit=lambda: None,
+        on_raise=lambda: None,
+        on_fullscreen=lambda _: None,
+    )
+
+    assert player._interface.get_property(PropertyName.CanQuit) is True
+    assert player._interface.get_property(PropertyName.CanRaise) is True
+    assert player._interface.get_property(PropertyName.CanSetFullscreen) is True
+
+
+def test_play_pause_callback_capability():
+    """Test that on_play_pause sets both CanPlay and CanPause."""
+    player = NowPlaying(
+        "Test Player",
+        on_play_pause=lambda: None,
+    )
+
+    assert player._interface.get_playback_property(PlaybackPropertyName.CanPlay) is True
+    assert player._interface.get_playback_property(PlaybackPropertyName.CanPause) is True
+    assert player._interface.get_playback_property(PlaybackPropertyName.CanControl) is True
+
+
+@pytest.mark.asyncio
+async def test_rate_callback_execution():
+    """Test that rate callback is executed."""
+    rates = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_rate=lambda r: rates.append(r),
+    )
+
+    await player._interface.on_rate(1.5)
+    await asyncio.sleep(0.1)
+
+    assert rates == [1.5]
+
+
+@pytest.mark.asyncio
+async def test_play_pause_callback_execution():
+    """Test that play_pause callback is executed."""
+    call_log = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_play_pause=lambda: call_log.append('play_pause'),
+    )
+
+    await player._interface.on_play_pause()
+    await asyncio.sleep(0.1)
+
+    assert 'play_pause' in call_log
+
+
+@pytest.mark.asyncio
+async def test_quit_callback_execution():
+    """Test that quit callback is executed."""
+    call_log = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_quit=lambda: call_log.append('quit'),
+    )
+
+    await player._interface.on_quit()
+    await asyncio.sleep(0.1)
+
+    assert 'quit' in call_log
+
+
+@pytest.mark.asyncio
+async def test_raise_callback_execution():
+    """Test that raise callback is executed."""
+    call_log = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_raise=lambda: call_log.append('raise'),
+    )
+
+    await player._interface.on_raise()
+    await asyncio.sleep(0.1)
+
+    assert 'raise' in call_log
+
+
+@pytest.mark.asyncio
+async def test_fullscreen_callback_execution():
+    """Test that fullscreen callback is executed."""
+    values = []
+
+    player = NowPlaying(
+        "Test Player",
+        on_fullscreen=lambda v: values.append(v),
+    )
+
+    await player._interface.on_fullscreen(True)
+    await asyncio.sleep(0.1)
+
+    assert values == [True]
+
+
+# Player-level property tests
+
+def test_identity_property():
+    """Test identity property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.identity = "Custom Identity"
+    assert player.identity == "Custom Identity"
+
+
+def test_desktop_entry_property():
+    """Test desktop_entry property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.desktop_entry = "my-player"
+    assert player.desktop_entry == "my-player"
+
+
+def test_supported_uri_schemes_property():
+    """Test supported_uri_schemes property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.supported_uri_schemes = ["http", "https", "file"]
+    assert player.supported_uri_schemes == ["http", "https", "file"]
+
+
+def test_supported_mime_types_property():
+    """Test supported_mime_types property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.supported_mime_types = ["audio/mpeg", "audio/ogg"]
+    assert player.supported_mime_types == ["audio/mpeg", "audio/ogg"]
+
+
+def test_has_track_list_property():
+    """Test has_track_list property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.has_track_list = True
+    assert player.has_track_list is True
+
+
+def test_can_quit_read_only():
+    """Test can_quit is read-only (set via callback)."""
+    player = NowPlaying("Test Player", on_quit=lambda: None)
+    assert player.can_quit is True
+
+    player2 = NowPlaying("Test Player")
+    assert player2.can_quit is False
+
+
+def test_can_raise_read_only():
+    """Test can_raise is read-only (set via callback)."""
+    player = NowPlaying("Test Player", on_raise=lambda: None)
+    assert player.can_raise is True
+
+    player2 = NowPlaying("Test Player")
+    assert player2.can_raise is False
+
+
+def test_can_set_fullscreen_read_only():
+    """Test can_set_fullscreen is read-only (set via callback)."""
+    player = NowPlaying("Test Player", on_fullscreen=lambda _: None)
+    assert player.can_set_fullscreen is True
+
+    player2 = NowPlaying("Test Player")
+    assert player2.can_set_fullscreen is False
+
+
+def test_fullscreen_property():
+    """Test fullscreen property getter/setter."""
+    player = NowPlaying("Test Player")
+    player.fullscreen = True
+    assert player.fullscreen is True
+
+
+# seeked and property access tests
+
+@pytest.mark.asyncio
+async def test_seeked_method():
+    """Test seeked method converts timedelta to microseconds."""
+    seeked_positions = []
+
+    class TestInterface(aionp.BaseInterface):
+        async def seeked(self, position: int):
+            seeked_positions.append(position)
+
+    player = NowPlaying("Test Player")
+    player._interface = TestInterface("Test Player")
+
+    await player.seeked(timedelta(seconds=5))
+    assert seeked_positions == [5_000_000]
+
+
+def test_set_property_get_property():
+    """Test set_property and get_property methods."""
+    player = NowPlaying("Test Player")
+    player.set_property(PropertyName.Identity, "Test Identity")
+    assert player.get_property(PropertyName.Identity) == "Test Identity"
+
+    player.set_property(PropertyName.DesktopEntry, "test-entry")
+    assert player.get_property(PropertyName.DesktopEntry) == "test-entry"


### PR DESCRIPTION
## Summary

- Add 5 missing callbacks: `on_rate`, `on_play_pause`, `on_quit`, `on_raise`, `on_fullscreen` with automatic capability flag setup
- Add 7 missing metadata properties: `id`, `media_type`, `lyrics`, `comments`, `composer`, `genre`, `lyricist`
- Add 8 player-level properties: `identity`, `desktop_entry`, `supported_uri_schemes`, `supported_mime_types`, `has_track_list`, `fullscreen`, `can_quit`, `can_raise`, `can_set_fullscreen`
- Add `seeked(position: timedelta)` method for seek event notification
- Add `set_property()` / `get_property()` for direct `PropertyName` access
- Export `MediaType` in `__init__.py`
- 25 new tests covering all additions