### PR TITLE
[feat] sync NowPlaying facade with BaseInterface

### DIFF
--- a/src/aionowplaying/__init__.py
+++ b/src/aionowplaying/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['NowPlaying', 'select_interface', 'BaseInterface', 'PropertyName', 'LoopStatus',
-           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus']
+           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus', 'TrackListPropertyName']
 
 import warnings
 from typing import Type
@@ -7,7 +7,7 @@ from typing import Type
 from aionowplaying.nowplaying import NowPlaying
 from aionowplaying.interface import select_interface, BaseInterface
 from aionowplaying.interface.base import PropertyName, LoopStatus, PlaybackPropertyName, PlaybackProperties, \
-    PlaybackStatus
+    PlaybackStatus, TrackListPropertyName
 
 
 def __getattr__(name: str):

--- a/src/aionowplaying/nowplaying.py
+++ b/src/aionowplaying/nowplaying.py
@@ -10,6 +10,7 @@ from aionowplaying.interface.base import (
     PlaybackPropertyName,
     PlaybackStatus,
     PropertyName,
+    TrackListPropertyName,
 )
 
 
@@ -38,6 +39,17 @@ class NowPlaying:
         on_volume: Callable[[float], Any] | None = None,
         on_shuffle: Callable[[bool], Any] | None = None,
         on_loop: Callable[[LoopStatus], Any] | None = None,
+        on_play_pause: Callable[[], Any] | None = None,
+        on_rate: Callable[[float], Any] | None = None,
+        on_open_uri: Callable[[str], Any] | None = None,
+        on_set_position: Callable[[str, timedelta], Any] | None = None,
+        on_get_tracks_metadata: Callable[[list[str]], Any] | None = None,
+        on_add_track: Callable[[str, str, bool], Any] | None = None,
+        on_remove_track: Callable[[str], Any] | None = None,
+        on_goto: Callable[[str], Any] | None = None,
+        on_fullscreen: Callable[[bool], Any] | None = None,
+        on_raise: Callable[[], Any] | None = None,
+        on_quit: Callable[[], Any] | None = None,
     ):
         self.name = name
         self._identity = identity or name
@@ -55,6 +67,17 @@ class NowPlaying:
             'on_volume': on_volume,
             'on_shuffle': on_shuffle,
             'on_loop': on_loop,
+            'on_play_pause': on_play_pause,
+            'on_rate': on_rate,
+            'on_open_uri': on_open_uri,
+            'on_set_position': on_set_position,
+            'on_get_tracks_metadata': on_get_tracks_metadata,
+            'on_add_track': on_add_track,
+            'on_remove_track': on_remove_track,
+            'on_goto': on_goto,
+            'on_fullscreen': on_fullscreen,
+            'on_raise': on_raise,
+            'on_quit': on_quit,
         }
 
         # Setup capabilities based on callbacks
@@ -100,8 +123,28 @@ class NowPlaying:
             if asyncio.iscoroutine(result):
                 asyncio.create_task(result)
 
+    async def _call_callback(self, name: str, *args) -> Any:
+        """Execute a callback and await async results when a return value matters."""
+        callback = self._callbacks.get(name)
+        if callback is None:
+            return None
+
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
     def _setup_callback_wrapper(self) -> None:
         """Set up callback wrappers to connect interface to user callbacks."""
+        async def wrapped_on_fullscreen(fullscreen: bool):
+            self._run_callback('on_fullscreen', fullscreen)
+
+        async def wrapped_on_raise():
+            self._run_callback('on_raise')
+
+        async def wrapped_on_quit():
+            self._run_callback('on_quit')
+
         async def wrapped_on_play():
             self._run_callback('on_play')
 
@@ -121,6 +164,12 @@ class NowPlaying:
         async def wrapped_on_stop():
             self._run_callback('on_stop')
 
+        async def wrapped_on_play_pause():
+            self._run_callback('on_play_pause')
+
+        async def wrapped_on_rate(rate: float):
+            self._run_callback('on_rate', rate)
+
         async def wrapped_on_volume(volume: float):
             self._run_callback('on_volume', volume)
 
@@ -130,16 +179,46 @@ class NowPlaying:
         async def wrapped_on_loop(status):
             self._run_callback('on_loop', status)
 
+        async def wrapped_on_open_uri(uri: str):
+            self._run_callback('on_open_uri', uri)
+
+        async def wrapped_on_set_position(track_id: str, position: int):
+            delta = self._microseconds_to_timedelta(position)
+            self._run_callback('on_set_position', track_id, delta)
+
+        async def wrapped_on_get_tracks_metadata(track_ids: list[str]):
+            return await self._call_callback('on_get_tracks_metadata', track_ids)
+
+        async def wrapped_on_add_track(uri: str, after_track: str, set_as_current: bool):
+            self._run_callback('on_add_track', uri, after_track, set_as_current)
+
+        async def wrapped_on_remove_track(track_id: str):
+            self._run_callback('on_remove_track', track_id)
+
+        async def wrapped_on_goto(track_id: str):
+            self._run_callback('on_goto', track_id)
+
         # Assign wrapped callbacks
+        self._interface.on_fullscreen = wrapped_on_fullscreen
+        self._interface.on_raise = wrapped_on_raise
+        self._interface.on_quit = wrapped_on_quit
         self._interface.on_play = wrapped_on_play
         self._interface.on_pause = wrapped_on_pause
         self._interface.on_next = wrapped_on_next
         self._interface.on_previous = wrapped_on_previous
         self._interface.on_seek = wrapped_on_seek
         self._interface.on_stop = wrapped_on_stop
+        self._interface.on_play_pause = wrapped_on_play_pause
+        self._interface.on_rate = wrapped_on_rate
         self._interface.on_volume = wrapped_on_volume
         self._interface.on_shuffle = wrapped_on_shuffle
         self._interface.on_loop_status = wrapped_on_loop
+        self._interface.on_open_uri = wrapped_on_open_uri
+        self._interface.on_set_position = wrapped_on_set_position
+        self._interface.on_get_tracks_metadata = wrapped_on_get_tracks_metadata
+        self._interface.on_add_track = wrapped_on_add_track
+        self._interface.on_remove_track = wrapped_on_remove_track
+        self._interface.on_goto = wrapped_on_goto
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
         """Apply metadata to the playback properties."""
@@ -189,6 +268,114 @@ class NowPlaying:
     def _microseconds_to_timedelta(us: int) -> timedelta:
         """Convert microseconds to timedelta."""
         return timedelta(microseconds=us)
+
+    def set_property(self, name: PropertyName, value: Any) -> None:
+        self._interface.set_property(name, value)
+        if name == PropertyName.Identity:
+            self._identity = value
+
+    def get_property(self, name: PropertyName) -> Any:
+        return self._interface.get_property(name)
+
+    def set_playback_property(self, name: PlaybackPropertyName, value: Any) -> None:
+        self._interface.set_playback_property(name, value)
+
+    def get_playback_property(self, name: PlaybackPropertyName) -> Any:
+        return self._interface.get_playback_property(name)
+
+    def set_tracklist_property(self, name: TrackListPropertyName, value: Any) -> None:
+        self._interface.set_tracklist_property(name, value)
+
+    def get_tracklist_property(self, name: TrackListPropertyName) -> Any:
+        return self._interface.get_tracklist_property(name)
+
+    @property
+    def identity(self) -> str:
+        return self.get_property(PropertyName.Identity)
+
+    @identity.setter
+    def identity(self, value: str):
+        self.set_property(PropertyName.Identity, value)
+
+    @property
+    def fullscreen(self) -> bool:
+        return self.get_property(PropertyName.Fullscreen)
+
+    @fullscreen.setter
+    def fullscreen(self, value: bool):
+        self.set_property(PropertyName.Fullscreen, value)
+
+    @property
+    def can_quit(self) -> bool:
+        return self.get_property(PropertyName.CanQuit)
+
+    @can_quit.setter
+    def can_quit(self, value: bool):
+        self.set_property(PropertyName.CanQuit, value)
+
+    @property
+    def can_set_fullscreen(self) -> bool:
+        return self.get_property(PropertyName.CanSetFullscreen)
+
+    @can_set_fullscreen.setter
+    def can_set_fullscreen(self, value: bool):
+        self.set_property(PropertyName.CanSetFullscreen, value)
+
+    @property
+    def can_raise(self) -> bool:
+        return self.get_property(PropertyName.CanRaise)
+
+    @can_raise.setter
+    def can_raise(self, value: bool):
+        self.set_property(PropertyName.CanRaise, value)
+
+    @property
+    def has_tracklist(self) -> bool:
+        return self.get_property(PropertyName.HasTrackList)
+
+    @has_tracklist.setter
+    def has_tracklist(self, value: bool):
+        self.set_property(PropertyName.HasTrackList, value)
+
+    @property
+    def desktop_entry(self) -> str:
+        return self.get_property(PropertyName.DesktopEntry)
+
+    @desktop_entry.setter
+    def desktop_entry(self, value: str):
+        self.set_property(PropertyName.DesktopEntry, value)
+
+    @property
+    def supported_uri_schemes(self) -> list[str]:
+        return self.get_property(PropertyName.SupportedUriSchemes)
+
+    @supported_uri_schemes.setter
+    def supported_uri_schemes(self, value: list[str]):
+        self.set_property(PropertyName.SupportedUriSchemes, value)
+
+    @property
+    def supported_mime_types(self) -> list[str]:
+        return self.get_property(PropertyName.SupportedMimeTypes)
+
+    @supported_mime_types.setter
+    def supported_mime_types(self, value: list[str]):
+        self.set_property(PropertyName.SupportedMimeTypes, value)
+
+    @property
+    def tracks(self) -> list[str]:
+        return self.get_tracklist_property(TrackListPropertyName.Tracks)
+
+    @tracks.setter
+    def tracks(self, value: list[str]):
+        self.set_tracklist_property(TrackListPropertyName.Tracks, value)
+
+    @property
+    def can_edit_tracks(self) -> bool:
+        return self.get_tracklist_property(TrackListPropertyName.CanEditTracks)
+
+    @can_edit_tracks.setter
+    def can_edit_tracks(self, value: bool):
+        self.set_tracklist_property(TrackListPropertyName.CanEditTracks, value)
 
     # Metadata properties
 
@@ -336,6 +523,26 @@ class NowPlaying:
         """Set playback rate."""
         self._interface.set_playback_property(PlaybackPropertyName.Rate, value)
 
+    @property
+    def minimum_rate(self) -> float:
+        """Get minimum playback rate."""
+        return self._interface.get_playback_property(PlaybackPropertyName.MinimumRate)
+
+    @minimum_rate.setter
+    def minimum_rate(self, value: float):
+        """Set minimum playback rate."""
+        self._interface.set_playback_property(PlaybackPropertyName.MinimumRate, value)
+
+    @property
+    def maximum_rate(self) -> float:
+        """Get maximum playback rate."""
+        return self._interface.get_playback_property(PlaybackPropertyName.MaximumRate)
+
+    @maximum_rate.setter
+    def maximum_rate(self, value: float):
+        """Set maximum playback rate."""
+        self._interface.set_playback_property(PlaybackPropertyName.MaximumRate, value)
+
     # State convenience methods
 
     def set_playing(self) -> None:
@@ -359,3 +566,23 @@ class NowPlaying:
     async def stop(self) -> None:
         """Stop the Now Playing backend."""
         await self._interface.stop()
+
+    async def track_added(self, metadata: PlaybackProperties.MetadataBean, after_track: str) -> None:
+        """Notify the backend that a track was added."""
+        await self._interface.track_added(metadata, after_track)
+
+    async def track_removed(self, track_id: str) -> None:
+        """Notify the backend that a track was removed."""
+        await self._interface.track_removed(track_id)
+
+    async def track_list_replaced(self, tracks: list[str], current_track: str) -> None:
+        """Notify the backend that the track list was replaced."""
+        await self._interface.track_list_replaced(tracks, current_track)
+
+    async def track_metadata_changed(self, track_id: str, metadata: PlaybackProperties.MetadataBean) -> None:
+        """Notify the backend that track metadata changed."""
+        await self._interface.track_metadata_changed(track_id, metadata)
+
+    async def seeked(self, position: timedelta) -> None:
+        """Notify the backend that playback was seeked."""
+        await self._interface.seeked(self._timedelta_to_microseconds(position))

--- a/tests/test_nowplaying.py
+++ b/tests/test_nowplaying.py
@@ -1,11 +1,12 @@
+import asyncio
+from datetime import timedelta
+import warnings
+
 import pytest
 
 import aionowplaying as aionp
-from aionowplaying import NowPlaying, PlaybackPropertyName, PlaybackStatus, LoopStatus
-from aionowplaying.interface.base import MediaType
-from datetime import timedelta
-import asyncio
-import warnings
+from aionowplaying import LoopStatus, NowPlaying, PlaybackPropertyName, PlaybackStatus
+from aionowplaying.interface.base import MediaType, PropertyName, TrackListPropertyName
 
 
 class DummyInterface(aionp.BaseInterface):
@@ -108,6 +109,7 @@ def test_nowplaying_init_with_identity():
     player = NowPlaying("Test Player", identity="Custom Identity")
     assert player.name == "Test Player"
     assert player._identity == "Custom Identity"
+    assert player.identity == "Custom Identity"
 
 
 def test_init_applies_metadata_mapping():
@@ -333,6 +335,60 @@ def test_rate_property():
     assert player.rate == 1.5
 
 
+def test_player_properties_and_tracklist_properties():
+    """Test player and tracklist property getters/setters."""
+    player = NowPlaying("Test Player")
+
+    player.identity = "Updated Identity"
+    player.fullscreen = True
+    player.can_quit = True
+    player.can_set_fullscreen = True
+    player.can_raise = True
+    player.has_tracklist = True
+    player.desktop_entry = "test-player"
+    player.supported_uri_schemes = ["file", "https"]
+    player.supported_mime_types = ["audio/mpeg"]
+    player.tracks = ["/track/1", "/track/2"]
+    player.can_edit_tracks = True
+
+    assert player.identity == "Updated Identity"
+    assert player._identity == "Updated Identity"
+    assert player.fullscreen is True
+    assert player.can_quit is True
+    assert player.can_set_fullscreen is True
+    assert player.can_raise is True
+    assert player.has_tracklist is True
+    assert player.desktop_entry == "test-player"
+    assert player.supported_uri_schemes == ["file", "https"]
+    assert player.supported_mime_types == ["audio/mpeg"]
+    assert player.tracks == ["/track/1", "/track/2"]
+    assert player.can_edit_tracks is True
+
+
+def test_minimum_and_maximum_rate_properties():
+    """Test minimum and maximum rate getters/setters."""
+    player = NowPlaying("Test Player")
+
+    player.minimum_rate = 0.5
+    player.maximum_rate = 2.0
+
+    assert player.minimum_rate == 0.5
+    assert player.maximum_rate == 2.0
+
+
+def test_generic_property_helpers():
+    """Test generic property helper methods."""
+    player = NowPlaying("Test Player")
+
+    player.set_property(PropertyName.DesktopEntry, "helper-entry")
+    player.set_playback_property(PlaybackPropertyName.CanControl, True)
+    player.set_tracklist_property(TrackListPropertyName.CanEditTracks, True)
+
+    assert player.get_property(PropertyName.DesktopEntry) == "helper-entry"
+    assert player.get_playback_property(PlaybackPropertyName.CanControl) is True
+    assert player.get_tracklist_property(TrackListPropertyName.CanEditTracks) is True
+
+
 @pytest.mark.asyncio
 async def test_start_stop_lifecycle():
     """Test start and stop lifecycle methods."""
@@ -373,6 +429,55 @@ async def test_callback_execution():
 
 
 @pytest.mark.asyncio
+async def test_extended_callbacks_are_forwarded():
+    """Test that newly exposed callbacks are wired to the facade."""
+    call_log = []
+    metadata_result = [aionp.PlaybackProperties.MetadataBean(id_="/track/1", title="Track 1")]
+
+    player = NowPlaying(
+        "Test Player",
+        on_play_pause=lambda: call_log.append("play_pause"),
+        on_rate=lambda rate: call_log.append(("rate", rate)),
+        on_open_uri=lambda uri: call_log.append(("open_uri", uri)),
+        on_set_position=lambda track_id, delta: call_log.append(("set_position", track_id, delta)),
+        on_get_tracks_metadata=lambda track_ids: metadata_result if track_ids == ["/track/1"] else [],
+        on_add_track=lambda uri, after_track, set_as_current: call_log.append(
+            ("add_track", uri, after_track, set_as_current)
+        ),
+        on_remove_track=lambda track_id: call_log.append(("remove_track", track_id)),
+        on_goto=lambda track_id: call_log.append(("goto", track_id)),
+        on_fullscreen=lambda fullscreen: call_log.append(("fullscreen", fullscreen)),
+        on_raise=lambda: call_log.append("raise"),
+        on_quit=lambda: call_log.append("quit"),
+    )
+
+    await player._interface.on_play_pause()
+    await player._interface.on_rate(1.25)
+    await player._interface.on_open_uri("https://example.com")
+    await player._interface.on_set_position("/track/1", 2_000_000)
+    result = await player._interface.on_get_tracks_metadata(["/track/1"])
+    await player._interface.on_add_track("file:///song.mp3", "/track/1", True)
+    await player._interface.on_remove_track("/track/1")
+    await player._interface.on_goto("/track/2")
+    await player._interface.on_fullscreen(True)
+    await player._interface.on_raise()
+    await player._interface.on_quit()
+    await asyncio.sleep(0.1)
+
+    assert result == metadata_result
+    assert "play_pause" in call_log
+    assert ("rate", 1.25) in call_log
+    assert ("open_uri", "https://example.com") in call_log
+    assert ("set_position", "/track/1", timedelta(seconds=2)) in call_log
+    assert ("add_track", "file:///song.mp3", "/track/1", True) in call_log
+    assert ("remove_track", "/track/1") in call_log
+    assert ("goto", "/track/2") in call_log
+    assert ("fullscreen", True) in call_log
+    assert "raise" in call_log
+    assert "quit" in call_log
+
+
+@pytest.mark.asyncio
 async def test_seek_callback_converts_microseconds_to_timedelta():
     """Test seek callback wrapper converts microseconds to timedelta."""
     offsets = []
@@ -403,6 +508,67 @@ async def test_async_callback_is_scheduled():
     await asyncio.wait_for(callback_done.wait(), timeout=1)
 
     assert seen == ["play"]
+
+
+@pytest.mark.asyncio
+async def test_get_tracks_metadata_async_callback_is_awaited():
+    """Test async metadata callback returns its result to the backend."""
+    callback_done = asyncio.Event()
+    expected = [aionp.PlaybackProperties.MetadataBean(id_="/track/async")]
+
+    async def on_get_tracks_metadata(track_ids):
+        assert track_ids == ["/track/async"]
+        callback_done.set()
+        return expected
+
+    player = NowPlaying("Test Player", on_get_tracks_metadata=on_get_tracks_metadata)
+
+    result = await player._interface.on_get_tracks_metadata(["/track/async"])
+    await asyncio.wait_for(callback_done.wait(), timeout=1)
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_track_events_and_seeked_are_forwarded(monkeypatch):
+    """Test facade event methods forward to the underlying interface."""
+    player = NowPlaying("Test Player")
+    calls = {}
+
+    async def fake_track_added(metadata, after_track):
+        calls["track_added"] = (metadata, after_track)
+
+    async def fake_track_removed(track_id):
+        calls["track_removed"] = track_id
+
+    async def fake_track_list_replaced(tracks, current_track):
+        calls["track_list_replaced"] = (tracks, current_track)
+
+    async def fake_track_metadata_changed(track_id, metadata):
+        calls["track_metadata_changed"] = (track_id, metadata)
+
+    async def fake_seeked(position):
+        calls["seeked"] = position
+
+    monkeypatch.setattr(player._interface, "track_added", fake_track_added)
+    monkeypatch.setattr(player._interface, "track_removed", fake_track_removed)
+    monkeypatch.setattr(player._interface, "track_list_replaced", fake_track_list_replaced)
+    monkeypatch.setattr(player._interface, "track_metadata_changed", fake_track_metadata_changed)
+    monkeypatch.setattr(player._interface, "seeked", fake_seeked)
+
+    metadata = aionp.PlaybackProperties.MetadataBean(id_="/track/1", title="Track 1")
+
+    await player.track_added(metadata, "/track/0")
+    await player.track_removed("/track/1")
+    await player.track_list_replaced(["/track/1", "/track/2"], "/track/2")
+    await player.track_metadata_changed("/track/1", metadata)
+    await player.seeked(timedelta(seconds=3))
+
+    assert calls["track_added"] == (metadata, "/track/0")
+    assert calls["track_removed"] == "/track/1"
+    assert calls["track_list_replaced"] == (["/track/1", "/track/2"], "/track/2")
+    assert calls["track_metadata_changed"] == ("/track/1", metadata)
+    assert calls["seeked"] == 3_000_000
 
 
 def test_select_interface_deprecation():


### PR DESCRIPTION
## Summary
- sync NowPlaying callback wiring with BaseInterface completed capabilities
- expose missing facade properties and generic property helpers
- add facade tests for callbacks, track events, and property get/set coverage

## Testing
- rtk env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_nowplaying.py -q
- rtk env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_base_interface.py tests/test_mpris2_interface.py -q