### PR TITLE
[Feature] Implement Playlists interface for Linux (MPRIS2)

### DIFF
--- a/src/aionowplaying/__init__.py
+++ b/src/aionowplaying/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['NowPlaying', 'select_interface', 'BaseInterface', 'PropertyName', 'LoopStatus',
-           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus']
+           'PlaybackPropertyName', 'PlaybackProperties', 'PlaybackStatus', 'PlaylistBean',
+           'PlaylistPropertyName', 'PlaylistOrdering']
 
 import warnings
 from typing import Type
@@ -7,7 +8,7 @@ from typing import Type
 from aionowplaying.nowplaying import NowPlaying
 from aionowplaying.interface import select_interface, BaseInterface
 from aionowplaying.interface.base import PropertyName, LoopStatus, PlaybackPropertyName, PlaybackProperties, \
-    PlaybackStatus
+    PlaybackStatus, PlaylistBean, PlaylistPropertyName, PlaylistOrdering
 
 
 def __getattr__(name: str):

--- a/src/aionowplaying/interface/base.py
+++ b/src/aionowplaying/interface/base.py
@@ -8,11 +8,26 @@ class TrackListPropertyName(str, Enum):
     CanEditTracks = 'CanEditTracks'
 
 
+class PlaylistPropertyName(str, Enum):
+    PlaylistCount = 'PlaylistCount'
+    Orderings = 'Orderings'
+    ActivePlaylist = 'ActivePlaylist'
+
+
+class PlaylistOrdering(str, Enum):
+    Alphabetical = 'Alphabetical'
+    CreationDate = 'CreationDate'
+    ModifiedDate = 'ModifiedDate'
+    PlayCount = 'PlayCount'
+    User = 'User'
+
+
 class PropertyName(str, Enum):
     CanQuit = "CanQuit"
     CanSetFullscreen = "CanSetFullscreen"
     CanRaise = "CanRaise"
     HasTrackList = "HasTrackList"
+    HasPlaylists = "HasPlaylists"
     Identity = "Identity"
     DesktopEntry = "DesktopEntry"
     SupportedUriSchemes = "SupportedUriSchemes"
@@ -62,12 +77,26 @@ class TrackListProperties(BaseModel):
     CanEditTracks: bool = False
 
 
+class PlaylistBean(BaseModel):
+    id_: str = ''
+    name: str = ''
+    icon: str = ''
+
+
+class PlaylistProperties(BaseModel):
+    PlaylistCount: int = 0
+    Orderings: List[str] = []
+    ActivePlaylistValid: bool = False
+    ActivePlaylist: PlaylistBean = PlaylistBean()
+
+
 class PlayerProperties(BaseModel):
     Fullscreen: bool = False
     CanQuit: bool = False
     CanSetFullscreen: bool = False
     CanRaise: bool = False
     HasTrackList: bool = False
+    HasPlaylists: bool = False
     Identity: str = ""
     DesktopEntry: str = ""
     SupportedUriSchemes: List[str] = []
@@ -116,6 +145,7 @@ class BaseInterface:
         self._properties = PlayerProperties()
         self._playback_properties = PlaybackProperties()
         self._tracklist_properties = TrackListProperties()
+        self._playlist_properties = PlaylistProperties()
 
     async def start(self):
         """
@@ -261,6 +291,15 @@ class BaseInterface:
     async def track_metadata_changed(self, track_id: str, metadata: PlaybackProperties.MetadataBean):
         pass
 
+    async def on_activate_playlist(self, playlist_id: str):
+        pass
+
+    async def on_get_playlists(self, index: int, max_count: int, order: str, reverse: bool) -> list[PlaylistBean]:
+        return []
+
+    async def playlist_changed(self, playlist: PlaylistBean):
+        pass
+
     async def seeked(self, position: int):
         pass
 
@@ -273,6 +312,9 @@ class BaseInterface:
     def set_tracklist_property(self, name: TrackListPropertyName, value: Any):
         setattr(self._tracklist_properties, name.value, value)
 
+    def set_playlist_property(self, name: PlaylistPropertyName, value: Any):
+        setattr(self._playlist_properties, name.value, value)
+
     def get_property(self, name: PropertyName) -> Any:
         return getattr(self._properties, name.value)
 
@@ -281,3 +323,6 @@ class BaseInterface:
 
     def get_tracklist_property(self, name: TrackListPropertyName) -> Any:
         return getattr(self._tracklist_properties, name.value)
+
+    def get_playlist_property(self, name: PlaylistPropertyName) -> Any:
+        return getattr(self._playlist_properties, name.value)

--- a/src/aionowplaying/interface/mpris2.py
+++ b/src/aionowplaying/interface/mpris2.py
@@ -7,7 +7,8 @@ from dbus_fast.aio import MessageBus
 from dbus_fast.service import ServiceInterface, dbus_property, method, signal
 
 from aionowplaying.interface.base import BaseInterface, PropertyName, PlayerProperties, PlaybackProperties, \
-    PlaybackPropertyName, LoopStatus, TrackListPropertyName, TrackListProperties
+    PlaybackPropertyName, LoopStatus, TrackListPropertyName, TrackListProperties, \
+    PlaylistPropertyName, PlaylistProperties, PlaylistBean
 
 
 class DBusBeanMapper:
@@ -48,6 +49,10 @@ class DBusBeanMapper:
         metadata_map['xesam:trackNumber'] = Variant('i', metadata.trackNumber)
         metadata_map['xesam:url'] = Variant('s', metadata.url)
         return metadata_map
+
+    @staticmethod
+    def playlist_tuple(playlist: PlaylistBean) -> tuple:
+        return (playlist.id_, playlist.name, playlist.icon)
 
 
 class MprisPlayerServiceInterface(ServiceInterface):
@@ -228,6 +233,10 @@ class MprisServiceInterface(ServiceInterface):
     def has_track_list(self) -> 'b':
         return self._properties.HasTrackList
 
+    @dbus_property(access=PropertyAccess.READ, name=PropertyName.HasPlaylists.value)
+    def has_playlists(self) -> 'b':
+        return self._properties.HasPlaylists
+
     @dbus_property(access=PropertyAccess.READ, name=PropertyName.CanRaise.value)
     def can_raise(self) -> 'b':
         return self._properties.CanRaise
@@ -328,6 +337,53 @@ class MprisTracklistServiceInterface(ServiceInterface):
         return getattr(self._properties, key)
 
 
+class MprisPlaylistsServiceInterface(ServiceInterface):
+    def __init__(self, bus_name: str, it: 'Mpris2Interface' = None):
+        super().__init__(bus_name)
+        self._properties = PlaylistProperties()
+        self._it = it
+
+    def set_property(self, name: str, value: Any):
+        setattr(self._properties, name, value)
+        if name == PlaylistPropertyName.ActivePlaylist.value:
+            valid = self._properties.ActivePlaylistValid
+            playlist = self._properties.ActivePlaylist
+            self.emit_properties_changed({name: (valid, DBusBeanMapper.playlist_tuple(playlist))})
+        else:
+            self.emit_properties_changed({name: value})
+
+    @dbus_property(access=PropertyAccess.READ, name=PlaylistPropertyName.PlaylistCount.value)
+    def playlist_count(self) -> 'u':
+        return self._properties.PlaylistCount
+
+    @dbus_property(access=PropertyAccess.READ, name=PlaylistPropertyName.Orderings.value)
+    def orderings(self) -> 'as':
+        return self._properties.Orderings
+
+    @dbus_property(access=PropertyAccess.READ, name=PlaylistPropertyName.ActivePlaylist.value)
+    def active_playlist(self) -> '(b(oss))':
+        return (
+            self._properties.ActivePlaylistValid,
+            DBusBeanMapper.playlist_tuple(self._properties.ActivePlaylist),
+        )
+
+    @signal(name="PlaylistChanged")
+    def playlist_changed(self, playlist: tuple) -> "(oss)":
+        return playlist
+
+    @method(name="ActivatePlaylist")
+    async def activate_playlist(self, playlist_id: 'o'):
+        await self._it.on_activate_playlist(playlist_id)
+
+    @method(name="GetPlaylists")
+    async def get_playlists(self, index: 'u', max_count: 'u', order: 's', reverse: 'b') -> 'a(oss)':
+        playlists = await self._it.on_get_playlists(index, max_count, order, reverse)
+        return [DBusBeanMapper.playlist_tuple(p) for p in playlists]
+
+    def get_property(self, key):
+        return getattr(self._properties, key)
+
+
 class Mpris2Interface(BaseInterface):
     def __init__(self, name: str):
         super().__init__(name)
@@ -336,11 +392,14 @@ class Mpris2Interface(BaseInterface):
         self._entry_name = 'org.mpris.MediaPlayer2'
         self._player_entry_name = 'org.mpris.MediaPlayer2.Player'
         self._player_tracklist_name = 'org.mpris.MediaPlayer2.TrackList'
+        self._player_playlists_name = 'org.mpris.MediaPlayer2.Playlists'
         self._object_path = '/org/mpris/MediaPlayer2'
         self._bus = MprisServiceInterface(self._entry_name, it=self)
         self._bus._properties.HasTrackList = True
+        self._bus._properties.HasPlaylists = True
         self._player_bus = MprisPlayerServiceInterface(self._player_entry_name, it=self)
         self._tracklist_bus = MprisTracklistServiceInterface(self._player_tracklist_name, it=self)
+        self._playlists_bus = MprisPlaylistsServiceInterface(self._player_playlists_name, it=self)
 
     def set_property(self, name: PropertyName, value: Any):
         self._bus.set_property(name.value, value)
@@ -351,6 +410,9 @@ class Mpris2Interface(BaseInterface):
     def set_tracklist_property(self, name: TrackListPropertyName, value: Any):
         self._tracklist_bus.set_property(name.value, value)
 
+    def set_playlist_property(self, name: PlaylistPropertyName, value: Any):
+        self._playlists_bus.set_property(name.value, value)
+
     def get_property(self, name: PropertyName) -> Any:
         return self._bus.get_property(name.value)
 
@@ -359,6 +421,9 @@ class Mpris2Interface(BaseInterface):
 
     def get_tracklist_property(self, name: TrackListPropertyName) -> Any:
         return self._tracklist_bus.get_property(name.value)
+
+    def get_playlist_property(self, name: PlaylistPropertyName) -> Any:
+        return self._playlists_bus.get_property(name.value)
 
     async def seeked(self, position: int):
         await self._player_bus.seeked(position)
@@ -393,11 +458,18 @@ class Mpris2Interface(BaseInterface):
         )
         return await self._maybe_await(result)
 
+    async def playlist_changed(self, playlist):
+        result = self._playlists_bus.playlist_changed(
+            DBusBeanMapper.playlist_tuple(playlist),
+        )
+        return await self._maybe_await(result)
+
     async def start(self):
         self.dbus = await MessageBus().connect()
         self.dbus.export(self._object_path, self._bus)
         self.dbus.export(self._object_path, self._player_bus)
         self.dbus.export(self._object_path, self._tracklist_bus)
+        self.dbus.export(self._object_path, self._playlists_bus)
         await self.dbus.request_name(self._bus_name)
         await self.dbus.wait_for_disconnect()
 

--- a/src/aionowplaying/nowplaying.py
+++ b/src/aionowplaying/nowplaying.py
@@ -9,6 +9,8 @@ from aionowplaying.interface.base import (
     PlaybackProperties,
     PlaybackPropertyName,
     PlaybackStatus,
+    PlaylistBean,
+    PlaylistPropertyName,
     PropertyName,
 )
 
@@ -38,6 +40,7 @@ class NowPlaying:
         on_volume: Callable[[float], Any] | None = None,
         on_shuffle: Callable[[bool], Any] | None = None,
         on_loop: Callable[[LoopStatus], Any] | None = None,
+        on_activate_playlist: Callable[[str], Any] | None = None,
     ):
         self.name = name
         self._identity = identity or name
@@ -55,6 +58,7 @@ class NowPlaying:
             'on_volume': on_volume,
             'on_shuffle': on_shuffle,
             'on_loop': on_loop,
+            'on_activate_playlist': on_activate_playlist,
         }
 
         # Setup capabilities based on callbacks
@@ -130,6 +134,9 @@ class NowPlaying:
         async def wrapped_on_loop(status):
             self._run_callback('on_loop', status)
 
+        async def wrapped_on_activate_playlist(playlist_id: str):
+            self._run_callback('on_activate_playlist', playlist_id)
+
         # Assign wrapped callbacks
         self._interface.on_play = wrapped_on_play
         self._interface.on_pause = wrapped_on_pause
@@ -140,6 +147,7 @@ class NowPlaying:
         self._interface.on_volume = wrapped_on_volume
         self._interface.on_shuffle = wrapped_on_shuffle
         self._interface.on_loop_status = wrapped_on_loop
+        self._interface.on_activate_playlist = wrapped_on_activate_playlist
 
     def _apply_metadata(self, metadata: dict[str, Any]) -> None:
         """Apply metadata to the playback properties."""
@@ -335,6 +343,35 @@ class NowPlaying:
     def rate(self, value: float):
         """Set playback rate."""
         self._interface.set_playback_property(PlaybackPropertyName.Rate, value)
+
+    # Playlist properties
+
+    @property
+    def active_playlist(self) -> PlaylistBean | None:
+        """Get the currently active playlist, or None if none is active."""
+        valid = self._interface._playlist_properties.ActivePlaylistValid
+        if not valid:
+            return None
+        return self._interface._playlist_properties.ActivePlaylist
+
+    @active_playlist.setter
+    def active_playlist(self, value: PlaylistBean | None):
+        """Set the active playlist."""
+        if value is None:
+            self._interface._playlist_properties.ActivePlaylistValid = False
+        else:
+            self._interface._playlist_properties.ActivePlaylistValid = True
+            self._interface._playlist_properties.ActivePlaylist = value
+
+    @property
+    def playlist_count(self) -> int:
+        """Get the number of available playlists."""
+        return self._interface._playlist_properties.PlaylistCount
+
+    @playlist_count.setter
+    def playlist_count(self, value: int):
+        """Set the number of available playlists."""
+        self._interface.set_playlist_property(PlaylistPropertyName.PlaylistCount, value)
 
     # State convenience methods
 

--- a/tests/test_mpris2_interface.py
+++ b/tests/test_mpris2_interface.py
@@ -181,8 +181,9 @@ async def test_mpris2_start_exports_tracklist_bus():
 
     exported_paths = [entry[0] for entry in it.dbus.exported]
     exported_ifaces = [entry[1] for entry in it.dbus.exported]
-    assert exported_paths.count("/org/mpris/MediaPlayer2") == 3
+    assert exported_paths.count("/org/mpris/MediaPlayer2") == 4
     assert any(isinstance(iface, mpris2.MprisTracklistServiceInterface) for iface in exported_ifaces)
+    assert any(isinstance(iface, mpris2.MprisPlaylistsServiceInterface) for iface in exported_ifaces)
     assert it.get_property(PropertyName.HasTrackList) is True
     monkeypatch.undo()
 


### PR DESCRIPTION
## 概述

实现 MPRIS2 `org.mpris.MediaPlayer2.Playlists` 接口，关闭 #18

## 变更内容

### 新增类型 (base.py)
- `PlaylistPropertyName` 枚举
- `PlaylistOrdering` 枚举  
- `PlaylistBean` Pydantic 模型
- `PlaylistProperties` Pydantic 模型
- `PropertyName.HasPlaylists` 属性

### 新增接口 (mpris2.py)
- `MprisPlaylistsServiceInterface` 类，实现：
  - `PlaylistCount` (u), `Orderings` (as), `ActivePlaylist` ((b(oss))) 属性
  - `ActivatePlaylist(o)`, `GetPlaylists(uusb)` 方法
  - `PlaylistChanged((oss))` 信号
- `MprisServiceInterface` 新增 `HasPlaylists` 属性

### Facade 层 (nowplaying.py)
- `on_activate_playlist` 回调支持
- `active_playlist` / `playlist_count` 便捷属性

### 导出 (__init__.py)
- 导出 `PlaylistBean`, `PlaylistPropertyName`, `PlaylistOrdering`

## 测试

- 更新现有测试断言以验证 4 个接口导出
- 所有 65 个测试通过